### PR TITLE
收到后端 tick_update/snapshot 消息后，更新状态为推演完成。

### DIFF
--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
   model: deepseek-chat
-  api_key: sk-8491d1e1ab684f0eb40ee31d864e8c31
-  base_url: https://api.deepseek.com/v1
+  api_key: 
+  base_url: 
   capabilities:
   - chat

--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
-  model: qwen3.5-flash
-  api_key: 
-  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model: deepseek-chat
+  api_key: sk-8491d1e1ab684f0eb40ee31d864e8c31
+  base_url: https://api.deepseek.com/v1
   capabilities:
   - chat

--- a/examples/deduction/frontend/app.js
+++ b/examples/deduction/frontend/app.js
@@ -358,6 +358,14 @@ function connect() {
 
         document.getElementById('startTickBtn').disabled = true;
         document.getElementById('applyTickBtn').disabled = false;
+
+        // 推演完成，更新状态文本提示用户可以开始模拟
+        const statusTxt = document.getElementById('statusText');
+        if (statusTxt) statusTxt.textContent = '推演完成';
+        const statusDot = document.getElementById('statusDot');
+        if (statusDot) {
+          statusDot.className = 'status-dot connected';
+        }
       } else if (msg.type === 'add_agent_response') {
         // 处理添加人物的响应
         handleAddAgentResponse(msg);


### PR DESCRIPTION
问题：ws.onmessage 处理 tick_update/snapshot 消息时，禁用开始按钮、启用应用按钮后，缺少更新 UI 状态指示器的逻辑，导致推演完成后状态栏仍停留在"正在推演..."。                                                                           
修改：在 app.js 的 ws.onmessage 中，applyTickBtn 启用后新增三行逻辑，包括将 statusText 文本更新为"推演完成"，并将 statusDot 的 class 重置为status-dot connected（绿色），与推演开始时设置"正在推演..."形成完整的状态闭环。  