### PR TITLE
Fix/deduction display

### DIFF
--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,0 @@
-- name: OpenAIProvider
-  model: deepseek-chat
-  api_key: 
-  base_url: https://api.deepseek.com/v1
-  capabilities:
-  - chat

--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
   model: deepseek-chat
-  api_key: sk-8491d1e1ab684f0eb40ee31d864e8c31
+  api_key: 
   base_url: https://api.deepseek.com/v1
   capabilities:
   - chat

--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
-  model: qwen3.5-flash
-  api_key: 
-  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model: deepseek-chat
+  api_key: sk-8491d1e1ab684f0eb40ee31d864e8c31
+  base_url: https://api.deepseek.com/v1
   capabilities:
   - chat

--- a/examples/deduction/frontend/app.js
+++ b/examples/deduction/frontend/app.js
@@ -358,6 +358,14 @@ function connect() {
 
         document.getElementById('startTickBtn').disabled = true;
         document.getElementById('applyTickBtn').disabled = false;
+
+        // 推演完成，更新状态文本提示用户可以开始模拟
+        const statusTxt = document.getElementById('statusText');
+        if (statusTxt) statusTxt.textContent = '推演完成';
+        const statusDot = document.getElementById('statusDot');
+        if (statusDot) {
+          statusDot.className = 'status-dot connected';
+        }
       } else if (msg.type === 'add_agent_response') {
         // 处理添加人物的响应
         handleAddAgentResponse(msg);


### PR DESCRIPTION
Issue: > Missing UI status update logic in ws.onmessage when handling tick_update/snapshot. After toggling the start/apply buttons, the status bar incorrectly hangs on "simulating...".

Fix: > Added UI state reset logic in app.js (ws.onmessage). Once applyTickBtn is enabled, the statusText is updated to "simulation complete" and the statusDot class is restored to status-dot connected (green). This properly closes the UI lifecycle initiated by the "simulating..." state.