### PR TITLE
feat: add dynamic replan for hourly plans and fix misc issues

### DIFF
--- a/examples/deduction/BasicPodManager.py
+++ b/examples/deduction/BasicPodManager.py
@@ -72,9 +72,10 @@ class BasicPodManager(PodManagerImpl):
                         remote_call("state", "is_active"),
                         remote_call("state", "get_inactive_reason"),
                         remote_call("state", "get_state", "current_tick"),
+                        remote_call("state", "get_replan_log"),
                     )
-                    
-                    long_task, current_plan, current_plan_note, current_action, occupied_by, dialogues, hourly_plans, short_mem, long_mem, profile, is_active, inactive_reason, current_tick = results
+
+                    long_task, current_plan, current_plan_note, current_action, occupied_by, dialogues, hourly_plans, short_mem, long_mem, profile, is_active, inactive_reason, current_tick, replan_log = results
 
                     # Calculate time index based on current tick and extract target location from the day's plan
                     tick_val = current_tick or 0
@@ -114,6 +115,7 @@ class BasicPodManager(PodManagerImpl):
                         "inactive_reason": inactive_reason,
                         "current_tick": current_tick or 0,
                         "current_location": current_location,
+                        "replan_log": replan_log or [],
                     }
                 except Exception as exc:
                     logger.error("collect_agents_data: failed for agent %s: %s", agent_id, exc)
@@ -160,9 +162,10 @@ class BasicPodManager(PodManagerImpl):
                 remote_call("state", "is_active"),
                 remote_call("state", "get_inactive_reason"),
                 remote_call("state", "get_state", "current_tick"),
+                remote_call("state", "get_replan_log"),
             )
 
-            long_task, current_plan, current_plan_note, current_action, occupied_by, dialogues, hourly_plans, short_mem, long_mem, profile, is_active, inactive_reason, current_tick = results
+            long_task, current_plan, current_plan_note, current_action, occupied_by, dialogues, hourly_plans, short_mem, long_mem, profile, is_active, inactive_reason, current_tick, replan_log = results
 
             tick_val = current_tick or 0
             current_location = None
@@ -199,6 +202,7 @@ class BasicPodManager(PodManagerImpl):
                 "inactive_reason": inactive_reason,
                 "current_tick": current_tick or 0,
                 "current_location": current_location,
+                "replan_log": replan_log or [],
             }
         except Exception as exc:
             logger.error(f"collect_single_agent_data: failed for agent {agent_id}: {exc}")

--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
-  model: qwen3.5-flash
+  model: deepseek-chat
   api_key: 
-  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  base_url: https://api.deepseek.com/v1
   capabilities:
   - chat

--- a/examples/deduction/configs/simulation_config.yaml
+++ b/examples/deduction/configs/simulation_config.yaml
@@ -9,7 +9,7 @@
 simulation:
   pod_size: 5
   init_batch_size: 5
-  max_ticks: 12
+  max_ticks: 100
 
 configs:
   environment: "environment_config.yaml"

--- a/examples/deduction/frontend/app.js
+++ b/examples/deduction/frontend/app.js
@@ -1780,7 +1780,7 @@ function renderDetail(id) {
     <div class="section-divider"><span>✧</span></div>
     ${renderExperiences(d.dialogues, d.short_term_memory, id)}
     <div class="section-divider"><span>✧</span></div>
-    ${renderHourlyPlans(d.hourly_plans, d.dialogues, id, d.occupied_by, d.current_plan_note, d.current_tick)}
+    ${renderHourlyPlans(d.hourly_plans, d.dialogues, id, d.occupied_by, d.current_plan_note, d.current_tick, d.replan_log)}
     <div class="section-divider"><span>✧</span></div>
     ${renderMemory('长期记忆', d.long_term_memory, 'long')}
   `;
@@ -1955,10 +1955,20 @@ function renderCurrentPlan(plan, actionDetail, occupiedBy, dialogues, agentId, p
   </section>`;
 }
 
-function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, currentPlanNote, tick) {
+function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, currentPlanNote, tick, replanLog) {
   const currentDay = Math.floor((tick || 0) / 12) + 1;
   const viewingDay = viewDays[agentId] || currentDay;
   const currentHour = (tick || 0) % 12;
+
+  // Build a lookup: day -> list of replan events, for quick access in rendering
+  const replanByDay = {};
+  if (Array.isArray(replanLog)) {
+    for (const ev of replanLog) {
+      const d = ev.day;
+      if (!replanByDay[d]) replanByDay[d] = [];
+      replanByDay[d].push(ev);
+    }
+  }
 
   // 获取特定天的计划
   let dayPlans = [];
@@ -1985,12 +1995,29 @@ function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, current
     daySelector = `<div class="day-selector">${dayButtons}</div>`;
   }
 
+  // Build replan notice banner for the day being viewed
+  const dayReplanEvents = replanByDay[viewingDay] || [];
+  let replanBanner = '';
+  if (dayReplanEvents.length > 0) {
+    const notices = dayReplanEvents.map(ev =>
+      `<div class="replan-notice-item">⚡ 第${ev.from_hour}时辰起重新规划：${escHtml(ev.reason)}</div>`
+    ).join('');
+    replanBanner = `<div class="replan-banner">${notices}</div>`;
+  }
+
   if (!dayPlans || !dayPlans.length) {
     return `<section class="info-section">
       <div class="section-title">一日计划</div>
       ${daySelector}
+      ${replanBanner}
       <div class="empty-text" style="padding:12px 0">第 ${viewingDay} 天暂无计划</div>
     </section>`;
+  }
+
+  // Build set of hours that were replanned (for badge display)
+  const replanedHours = new Set();
+  for (const ev of dayReplanEvents) {
+    for (let h = ev.from_hour; h < 12; h++) replanedHours.add(h);
   }
 
   const items = dayPlans.map(p => {
@@ -1999,7 +2026,10 @@ function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, current
     const imp = parseInt(importance) || 1;
     const impClass = imp <= 3 ? 'imp-low' : imp <= 6 ? 'imp-mid' : imp <= 8 ? 'imp-high' : 'imp-crit';
     const targetStr = target && target !== '无' && target !== '自己' ? `→ ${escHtml(target)}` : '';
-    
+
+    // Badge shown on replanned hours
+    const replanBadge = replanedHours.has(time) ? '<span class="replan-badge">重规划</span>' : '';
+
     // 检查该时辰是否被占用
     const isCurrentlyOccupied = (viewingDay === currentDay && time === currentHour) && currentOccupiedBy;
     // 检查该时辰是否有注释
@@ -2045,7 +2075,7 @@ function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, current
     const isNow = (viewingDay === currentDay && time === currentHour);
 
     return `<div class="hourly-item${clickableClass}${isNow ? ' current-hour' : ''}" ${clickHandler}>
-      <div class="hourly-time"><span class="shichen">${shi}时</span></div>
+      <div class="hourly-time"><span class="shichen">${shi}时</span>${replanBadge}</div>
       <div class="hourly-line"><div class="hourly-dot ${impClass}"></div></div>
       <div class="hourly-content">
         ${contentHtml}
@@ -2057,6 +2087,7 @@ function renderHourlyPlans(plans, dialogues, agentId, currentOccupiedBy, current
   return `<section class="info-section">
     <div class="section-title">一日计划</div>
     ${daySelector}
+    ${replanBanner}
     <div class="hourly-list">${items}</div>
   </section>`;
 }

--- a/examples/deduction/frontend/style.css
+++ b/examples/deduction/frontend/style.css
@@ -725,6 +725,34 @@ body {
   padding: 4px 8px;
 }
 
+/* 重规划提示 banner */
+.replan-banner {
+  margin-bottom: 12px;
+  padding: 8px 12px;
+  background: rgba(180, 90, 30, 0.08);
+  border-left: 3px solid #b45a1e;
+  border-radius: 0 4px 4px 0;
+}
+.replan-notice-item {
+  font-size: 12px;
+  color: #b45a1e;
+  line-height: 1.6;
+}
+
+/* 重规划 badge，显示在时辰标签旁 */
+.replan-badge {
+  display: block;
+  margin-top: 4px;
+  padding: 1px 5px;
+  font-size: 10px;
+  font-family: var(--font-body);
+  color: #fff;
+  background: #b45a1e;
+  border-radius: 3px;
+  letter-spacing: 0;
+  font-weight: bold;
+}
+
 /* 时辰计划列表 */
 /* 每日计划切换 */
 .day-selector {

--- a/examples/deduction/plugins/agent/plan/BasicPlanPlugin.py
+++ b/examples/deduction/plugins/agent/plan/BasicPlanPlugin.py
@@ -164,8 +164,9 @@ class BasicPlanPlugin(PlanPlugin):
                     long_task=current_long_task
                 )
 
-                # Store hourly plans to state
-                await state_plugin.set_hourly_plans(hourly_plans)
+                # Store hourly plans to state (pass current_tick explicitly to avoid
+                # timing issues: state.execute() runs after plan in component_order)
+                await state_plugin.set_hourly_plans(hourly_plans, tick=current_tick)
                 logger.info(f"[{self.agent_id}][{current_tick}] Generated and stored 12 hourly plans")
             else:
                 logger.debug(f"[{self.agent_id}][{current_tick}] Not a plan generation cycle, skipping hourly plan generation")
@@ -495,3 +496,149 @@ class BasicPlanPlugin(PlanPlugin):
             logger.info(f"[{agent_id}][{current_tick}] No plans interacting with other characters in a day")
 
         return hourly_plans
+
+    async def replan_remaining_plans(self, agent_id: str, current_tick: int,
+                                     profile: Dict[str, Any], long_task: str = None,
+                                     start_hour: int = 0) -> List[List[Any]]:
+        """
+        Regenerate remaining hourly plans (starting from start_hour)
+
+        Args:
+            agent_id: Agent ID
+            current_tick: Current tick number
+            profile: Agent profile data
+            long_task: Agent long-term task
+            start_hour: Starting hour (which hour to start generating from)
+
+        Returns:
+            List[List[Any]]: Regenerated hourly plans list
+        """
+        if not profile:
+            logger.warning(f"[{agent_id}][{current_tick}] No profile provided, using default configuration")
+            profile = {}
+
+        # Format character profile
+        formatted_profile = self._format_profile_for_prompt(profile)
+
+        # Get all characters info
+        all_agent_ids = await self._get_all_agent_ids()
+        characters_info = self._format_characters_info(all_agent_ids)
+
+        # Build prompt - only generate remaining hours
+        remaining_hours = 12 - start_hour
+        long_task_info = f"\n\n【长期目标】\n{long_task}" if long_task else ""
+
+        # Build location constraint text
+        if self._available_locations:
+            locations_str = "、".join(self._available_locations)
+            location_rule = f"6. 【严格限制】地点必须从以下列表中选择，不能使用列表外的地点：\n   {locations_str}"
+        else:
+            location_rule = "6. 地点必须是具体的场所（如：怡红院、潇湘馆、荣庆堂等）"
+
+        # Build hour mapping
+        hour_names = ["子时(23-1点)", "丑时(1-3点)", "寅时(3-5点)", "卯时(5-7点)",
+                      "辰时(7-9点)", "巳时(9-11点)", "午时(11-13点)", "未时(13-15点)",
+                      "申时(15-17点)", "酉时(17-19点)", "戌时(19-21点)", "亥时(21-23点)"]
+        hour_context = "\n".join([f"{i}-{hour_names[i]}" for i in range(start_hour, 12)])
+
+        prompt = f"""你是一个智能体的时辰计划生成器。请根据以下人物档案信息，生成该人物剩余{remaining_hours}个时辰的详细行动计划。
+
+【重要背景】
+- 你当前处于红楼梦第80回
+- 请生成符合当前情节背景的计划
+- 【重要】这是重新规划，只需要为从第{start_hour}个时辰之后的时间生成计划
+
+【当前世界角色】
+{characters_info}
+
+{formatted_profile}{long_task_info}
+
+剩余时辰对应：
+{hour_context}
+
+要求：
+1. 仅为从第{start_hour}个时辰之后的时间生成计划（共{remaining_hours}个时辰）
+2. 行动必须符合人物性格、身份和核心驱动
+3. 行动要具体，包含动作、目标人物和地点
+4. 【重要建议】大部分时间应该专注于自己的事情
+   - 建议只有1-2个时辰涉及与其他具体人物的互动
+   - 其他时辰的target填写"自己"或"无"
+5. 【关键】目标人物必须使用全名，不能使用简称
+{location_rule}
+7. 行动描述控制在10-20字
+8. 为每个行动评估重要性分数(1-10)
+9. 严格按照JSON格式返回，不要有任何其他文字
+10. 必须使用中文输出
+
+请按以下JSON格式返回{remaining_hours}个时辰的计划：
+[
+  {{"action": "行动描述", "time": {start_hour}, "target": "目标人物", "location": "地点", "importance": 重要性分数}},
+  {{"action": "行动描述", "time": {start_hour+1}, "target": "目标人物", "location": "地点", "importance": 重要性分数}},
+  ...
+  {{"action": "行动描述", "time": 11, "target": "目标人物", "location": "地点", "importance": 重要性分数}}
+]"""
+
+        try:
+            if not self.model:
+                logger.error(f"[{agent_id}][{current_tick}] Model not initialized, cannot replan")
+                raise Exception("Model not initialized")
+
+            response = await self.model.chat(prompt)
+            response = response.strip()
+
+            # Parse JSON response
+            import json
+            start_idx = response.find('[')
+            end_idx = response.rfind(']') + 1
+            if start_idx != -1 and end_idx > start_idx:
+                json_str = response[start_idx:end_idx]
+                plans_data = json.loads(json_str)
+            else:
+                plans_data = json.loads(response)
+
+            # Merge old and new plans: keep executed, update remaining
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+            current_day = (current_tick // 12) + 1
+            hourly_plans = await state_plugin.get_hourly_plans(day=current_day)
+
+            # Build new plan list
+            new_plans = []
+            for hour in range(12):
+                if hour < start_hour:
+                    # Keep executed plans
+                    if hourly_plans:
+                        for plan in hourly_plans:
+                            if len(plan) >= 5 and plan[1] == hour:
+                                new_plans.append(plan)
+                                break
+                    else:
+                        # Create empty placeholder if no existing plan
+                        new_plans.append(["", hour, "自己", "", 1])
+                else:
+                    # Add newly generated plans
+                    found = False
+                    for plan_data in plans_data:
+                        if plan_data['time'] == hour:
+                            hourly_plan = HourlyPlan(
+                                action=plan_data['action'],
+                                time=plan_data['time'],
+                                target=plan_data['target'],
+                                location=plan_data['location'],
+                                importance=plan_data['importance']
+                            )
+                            new_plans.append(hourly_plan.to_list())
+                            found = True
+                            break
+                    if not found:
+                        # Create default plan if no corresponding hour plan found
+                        new_plans.append(["休息", hour, "自己", "", 1])
+
+            # Save new plans (pass current_tick explicitly for correct day calculation)
+            await state_plugin.set_hourly_plans(new_plans, tick=current_tick)
+            logger.info(f"[{agent_id}][{current_tick}] Remaining plans replanning completed, total {len(new_plans)} hours")
+            return new_plans
+
+        except Exception as e:
+            logger.error(f"[{agent_id}][{current_tick}] Failed to replan remaining plans: {e}")
+            raise

--- a/examples/deduction/plugins/agent/reflect/BasicReflectPlugin.py
+++ b/examples/deduction/plugins/agent/reflect/BasicReflectPlugin.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 from agentkernel_distributed.types.schemas.message import Message
 from agentkernel_distributed.mas.agent.base.plugin_base import ReflectPlugin
 from agentkernel_distributed.toolkit.logger import get_logger
@@ -22,15 +22,26 @@ class BasicReflectPlugin(ReflectPlugin):
 
     async def execute(self, current_tick: int) -> None:
         """
-        Perform a lightweight survival check every tick, and a full reflection logic every 12 ticks
+        Perform a lightweight survival check every tick.
+        Full reflection logic (summary, task check, adjustment) every 12 ticks.
+        Replan check every tick based on last tick's short-term memory.
         """
         # Perform lightweight survival check every tick (read-only short-term memory)
         if await self._check_life_status_lightweight(current_tick):
             return
 
-        # Check if it's a reflection cycle (executed every 12 ticks)
+        # Check if replanning is needed based on last tick's memory (every tick)
+        # Only check if there are remaining hours (not the last hour of the day)
+        current_hour = current_tick % 12
+        if current_hour < 11:  # Only replan if there are remaining hours in the day
+            should_replan, replan_reason = await self._should_replan(current_tick)
+            if should_replan:
+                logger.info(f"[{self.agent_id}][{current_tick}] Detected need to replan: {replan_reason}")
+                await self._replan_remaining(current_tick, replan_reason)
+
+        # Full reflection logic every 12 ticks
         if (current_tick + 1) % 12 == 0:
-            logger.info(f"[{self.agent_id}][{current_tick}] Starting reflection logic")
+            logger.info(f"[{self.agent_id}][{current_tick}] Starting full reflection logic")
 
             try:
                 # 1. Summarize short-term memory
@@ -47,9 +58,9 @@ class BasicReflectPlugin(ReflectPlugin):
                 # 4. Dynamically adjust LongTask (if not completed)
                 await self._adjust_long_task(current_tick)
 
-                logger.info(f"[{self.agent_id}][{current_tick}] Reflection logic execution completed")
+                logger.info(f"[{self.agent_id}][{current_tick}] Full reflection logic execution completed")
             except Exception as e:
-                logger.error(f"[{self.agent_id}][{current_tick}] Error executing reflection logic: {e}")
+                logger.error(f"[{self.agent_id}][{current_tick}] Error executing full reflection logic: {e}")
 
     async def reflect_task(self, task: LongTask, type: str, current_tick: int = None) -> None:
         """
@@ -487,3 +498,135 @@ class BasicReflectPlugin(ReflectPlugin):
 
         except Exception as e:
             logger.error(f"[{self.agent_id}][{current_tick}] Error adjusting LongTask: {e}")
+
+    async def _should_replan(self, current_tick: int) -> Tuple[bool, str]:
+        """
+        Determine if remaining hourly plans need to be replanned
+
+        Returns:
+            Tuple[bool, str]: (whether needs replanning, reason)
+        """
+        try:
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+
+            # Get current LongTask
+            long_task = await state_plugin.get_long_task()
+            if not long_task:
+                return (False, "No long-term task")
+
+            # Get short-term memory from last tick
+            short_memories = await state_plugin.get_short_term_memory()
+            if not short_memories:
+                return (False, "No short-term memory")
+
+            last_memory = short_memories[-1]
+            last_memory_text = last_memory.get('content', str(last_memory))
+
+            # Get current hour and remaining hours
+            current_hour = current_tick % 12
+            remaining_hours = 12 - current_hour - 1
+
+            # Get remaining unexecuted hourly plans
+            current_day = (current_tick // 12) + 1
+            hourly_plans = await state_plugin.get_hourly_plans(day=current_day)
+
+            remaining_plans = []
+            if hourly_plans:
+                for plan in hourly_plans:
+                    if len(plan) >= 5 and plan[1] > current_hour:
+                        remaining_plans.append(plan)
+
+            remaining_plans_text = "\n".join([
+                f"- Hour {plan[1]}: {plan[0]} (target:{plan[2]}, location:{plan[3]})"
+                for plan in remaining_plans
+            ]) if remaining_plans else "No remaining plans"
+
+            # Build Prompt
+            prompt = f"""你是一个智能体的计划评估助手。请根据近期记忆，判断是否需要重新规划剩余时间。
+
+当前长期任务：{long_task}
+
+上一tick发生的事件：{last_memory_text}
+
+当前时间：第{current_day}天 第{current_hour}个时辰（还剩{remaining_hours}个时辰）
+
+剩余未执行计划：
+{remaining_plans_text}
+
+判断标准：
+1. 上一tick是否发生了重大变化（如重要角色死亡、任务完成、突发事件）
+2. 当前任务是否已经失效或偏离
+3. 继续执行原计划是否合理
+
+请返回（仅返回结论）：
+- 需要重新规划："需要重新规划 | 原因"
+- 无需规划："无需规划 | 原因"
+"""
+
+            result = await self.model.chat(prompt)
+            result = result.strip()
+
+            logger.info(f"[{self.agent_id}][{current_tick}] Plan replanning decision result: {result}")
+
+            if "需要重新规划" in result:
+                parts = result.split('|')
+                reason = parts[1].strip() if len(parts) > 1 else "Major change occurred"
+                return (True, reason)
+            else:
+                return (False, result)
+
+        except Exception as e:
+            logger.error(f"[{self.agent_id}][{current_tick}] Error determining replanning: {e}")
+            return (False, f"Error: {str(e)}")
+
+    async def _replan_remaining(self, current_tick: int, reason: str) -> None:
+        """
+        Regenerate remaining hourly plans
+
+        Args:
+            current_tick: current tick
+            reason: replanning reason
+        """
+        try:
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+
+            profile_component = self._component.agent.get_component("profile")
+            profile_plugin = profile_component.get_plugin()
+            profile = profile_plugin.get_agent_profile()
+
+            # Get current LongTask
+            long_task = await state_plugin.get_long_task()
+
+            # Calculate current hour and remaining hours
+            current_hour = current_tick % 12
+            current_day = (current_tick // 12) + 1
+
+            logger.info(f"[{self.agent_id}][{current_tick}] Starting to regenerate remaining plans, current hour {current_hour}, remaining {12-current_hour-1} hours")
+
+            # Call PlanPlugin to regenerate remaining plans
+            plan_component = self._component.agent.get_component("plan")
+            if plan_component:
+                plan_plugin = plan_component.get_plugin()
+                # Call the new replan method
+                await plan_plugin.replan_remaining_plans(
+                    agent_id=self.agent_id,
+                    current_tick=current_tick,
+                    profile=profile,
+                    long_task=long_task,
+                    start_hour=current_hour + 1
+                )
+                logger.info(f"[{self.agent_id}][{current_tick}] Remaining plans replanning completed")
+                # Record the replan event so the frontend can highlight changed plan items
+                await state_plugin.add_replan_event(
+                    tick=current_tick,
+                    reason=reason,
+                    day=current_day,
+                    from_hour=current_hour + 1,
+                )
+            else:
+                logger.warning(f"[{self.agent_id}][{current_tick}] Cannot get plan component")
+
+        except Exception as e:
+            logger.error(f"[{self.agent_id}][{current_tick}] Error replanning remaining plans: {e}")

--- a/examples/deduction/plugins/agent/state/BasicStatePlugin.py
+++ b/examples/deduction/plugins/agent/state/BasicStatePlugin.py
@@ -50,6 +50,9 @@ class BasicStatePlugin(StatePlugin):
         elif isinstance(self.state_data['hourly_plans'], list):
             old_list = self.state_data['hourly_plans']
             self.state_data['hourly_plans'] = {1: old_list}
+        # Initialize replan log (records each time plans are dynamically changed mid-day)
+        if 'replan_log' not in self.state_data:
+            self.state_data['replan_log'] = []
 
     async def init(self) -> None:
         """Initialize StatePlugin, get agent_id from component"""
@@ -116,20 +119,50 @@ class BasicStatePlugin(StatePlugin):
         """
         return await self.get_state('long_task')
 
-    async def set_hourly_plans(self, hourly_plans: list) -> None:
+    async def set_hourly_plans(self, hourly_plans: list, tick: int = None) -> None:
         """
         Set 12 hourly plans, stored by day
 
         Args:
             hourly_plans: 12 hourly plans list, format is List[List[Any]]
+            tick: The tick to use for day calculation. If None, uses self.current_tick.
+                  Pass current_tick explicitly to avoid timing issues since the state
+                  component executes after plan/invoke in the component order.
         """
-        day = (self.current_tick // 12) + 1
+        effective_tick = tick if tick is not None else self.current_tick
+        day = (effective_tick // 12) + 1
         
         if 'hourly_plans' not in self.state_data or not isinstance(self.state_data['hourly_plans'], dict):
             self.state_data['hourly_plans'] = {}
             
         self.state_data['hourly_plans'][day] = hourly_plans
         logger.info(f"[{self.agent_id}][{self.current_tick}] Day {day} 12 hourly plans set, total {len(hourly_plans)} hours")
+
+    async def add_replan_event(self, tick: int, reason: str, day: int, from_hour: int) -> None:
+        """
+        Record a mid-day replan event for frontend display.
+
+        Args:
+            tick: The tick at which replanning occurred
+            reason: Why replanning was triggered
+            day: Which day's plans were changed
+            from_hour: Starting hour of the newly generated plans
+        """
+        if 'replan_log' not in self.state_data:
+            self.state_data['replan_log'] = []
+        self.state_data['replan_log'].append({
+            'tick': tick,
+            'reason': reason,
+            'day': day,
+            'from_hour': from_hour,
+        })
+        logger.info(f"[{self.agent_id}][{tick}] Replan event recorded: day {day}, from hour {from_hour}, reason: {reason}")
+
+    async def get_replan_log(self) -> list:
+        """
+        Return the full list of replan events.
+        """
+        return self.state_data.get('replan_log', [])
 
     async def get_hourly_plans(self, day: int = None) -> Optional[Any]:
         """

--- a/examples/deduction/plugins/agent/state/component.py
+++ b/examples/deduction/plugins/agent/state/component.py
@@ -68,3 +68,21 @@ class BasicStateComponent(StateComponent):
         if not self._plugin:
             return []
         return await self._plugin.get_short_term_memory()
+
+    async def get_hourly_plans(self, day: int = None) -> Any:
+        """Delegate get_hourly_plans to plugin."""
+        if not self._plugin:
+            return None
+        return await self._plugin.get_hourly_plans(day)
+
+    async def add_replan_event(self, tick: int, reason: str, day: int, from_hour: int) -> None:
+        """Delegate add_replan_event to plugin."""
+        if not self._plugin:
+            return
+        return await self._plugin.add_replan_event(tick, reason, day, from_hour)
+
+    async def get_replan_log(self) -> List[Any]:
+        """Delegate get_replan_log to plugin."""
+        if not self._plugin:
+            return []
+        return await self._plugin.get_replan_log()

--- a/examples/deduction/run_simulation.py
+++ b/examples/deduction/run_simulation.py
@@ -224,7 +224,7 @@ async def main():
         logger.info(f'【System】Simulation finished.')
 
         # ===== Step4 : Split logs by character =====
-        from examples.deduction.scripts.split_logs_by_character import process_log_directory
+        from examples.deduction.map.scripts.split_logs_by_character import process_log_directory
         log_dir = Path(project_path) / "logs"
         output_dir = log_dir / "character"
         logger.info(f'【System】Splitting logs by character...')

--- a/examples/deduction_en/configs/simulation_config.yaml
+++ b/examples/deduction_en/configs/simulation_config.yaml
@@ -9,7 +9,7 @@
 simulation:
   pod_size: 5
   init_batch_size: 5
-  max_ticks: 12
+  max_ticks: 100
 
 configs:
   environment: "environment_config.yaml"

--- a/examples/deduction_en/plugins/agent/plan/BasicPlanPlugin.py
+++ b/examples/deduction_en/plugins/agent/plan/BasicPlanPlugin.py
@@ -148,7 +148,8 @@ class BasicPlanPlugin(PlanPlugin):
                     long_task=current_long_task
                 )
 
-                await state_plugin.set_hourly_plans(hourly_plans)
+                # Pass current_tick explicitly for correct day calculation
+                await state_plugin.set_hourly_plans(hourly_plans, tick=current_tick)
                 logger.info(f"[{self.agent_id}][{current_tick}] Generated and stored 12 hourly plans")
             else:
                 logger.debug(f"[{self.agent_id}][{current_tick}] Not a plan generation cycle, skipping hourly plan generation")
@@ -402,3 +403,149 @@ Please return the 12-hour plan in the following JSON format:
             logger.info(f"[{agent_id}][{current_tick}] No plans interacting with other characters in a day")
 
         return hourly_plans
+
+    async def replan_remaining_plans(self, agent_id: str, current_tick: int,
+                                     profile: Dict[str, Any], long_task: str = None,
+                                     start_hour: int = 0) -> List[List[Any]]:
+        """
+        Regenerate remaining hourly plans (starting from start_hour)
+
+        Args:
+            agent_id: Agent ID
+            current_tick: Current tick number
+            profile: Agent profile data
+            long_task: Agent long-term task
+            start_hour: Starting hour (which hour to start generating from)
+
+        Returns:
+            List[List[Any]]: Regenerated hourly plans list
+        """
+        if not profile:
+            logger.warning(f"[{agent_id}][{current_tick}] No profile provided, using default configuration")
+            profile = {}
+
+        # Format character profile
+        formatted_profile = self._format_profile_for_prompt(profile)
+
+        # Get all characters info
+        all_agent_ids = await self._get_all_agent_ids()
+        characters_info = self._format_characters_info(all_agent_ids)
+
+        # Build prompt - only generate remaining hours
+        remaining_hours = 12 - start_hour
+        long_task_info = f"\n\n【Long-term Goal】\n{long_task}" if long_task else ""
+
+        # Build location constraint text
+        if self._available_locations:
+            locations_str = "、".join(self._available_locations)
+            location_rule = f"6. 【Strict Limit】Location must be chosen from the following list:\n   {locations_str}"
+        else:
+            location_rule = "6. Location must be a specific place (e.g., 怡红院, 潇湘馆, 荣庆堂)"
+
+        # Build hour mapping
+        hour_names = ["Zi(23-1)", "Chou(1-3)", "Yin(3-5)", "Mao(5-7)",
+                      "Chen(7-9)", "Si(9-11)", "Wu(11-13)", "Wei(13-15)",
+                      "Shen(15-17)", "You(17-19)", "Xu(19-21)", "Hai(21-23)"]
+        hour_context = "\n".join([f"{i}-{hour_names[i]}" for i in range(start_hour, 12)])
+
+        prompt = f"""You are an agent hour plan generator. Based on the following character profile, generate detailed action plans for the remaining {remaining_hours} hours.
+
+【Important Background】
+- You are currently at Dream of the Red Chamber Chapter 80
+- Please generate plans that fit the current plot context
+- 【Important】This is replanning, only need to generate plans for hours after hour {start_hour}
+
+【Current World Characters】
+{characters_info}
+
+{formatted_profile}{long_task_info}
+
+Remaining hours:
+{hour_context}
+
+Requirements:
+1. Only generate plans for hours after hour {start_hour} (total {remaining_hours} hours)
+2. Actions must match character personality, status, and core motivation
+3. Actions must be specific, including action, target character, and location
+4. 【Important Suggestion】Most time should be spent on personal matters
+   - Suggest only 1-2 hours involve interaction with specific characters
+   - Other hours: target should be "self" or "none"
+5. 【Critical】Target character must use full name, not nickname
+{location_rule}
+7. Action description should be 10-20 characters
+8. Evaluate importance score (1-10) for each action
+9. Return strictly in JSON format, no other text
+10. Must use English for plan content
+
+Return in the following JSON format for {remaining_hours} hours:
+[
+  {{"action": "action description", "time": {start_hour}, "target": "target character", "location": "location", "importance": score}},
+  {{"action": "action description", "time": {start_hour+1}, "target": "target character", "location": "location", "importance": score}},
+  ...
+  {{"action": "action description", "time": 11, "target": "target character", "location": "location", "importance": score}}
+]"""
+
+        try:
+            if not self.model:
+                logger.error(f"[{agent_id}][{current_tick}] Model not initialized, cannot replan")
+                raise Exception("Model not initialized")
+
+            response = await self.model.chat(prompt)
+            response = response.strip()
+
+            # Parse JSON response
+            import json
+            start_idx = response.find('[')
+            end_idx = response.rfind(']') + 1
+            if start_idx != -1 and end_idx > start_idx:
+                json_str = response[start_idx:end_idx]
+                plans_data = json.loads(json_str)
+            else:
+                plans_data = json.loads(response)
+
+            # Merge old and new plans: keep executed, update remaining
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+            current_day = (current_tick // 12) + 1
+            hourly_plans = await state_plugin.get_hourly_plans(day=current_day)
+
+            # Build new plan list
+            new_plans = []
+            for hour in range(12):
+                if hour < start_hour:
+                    # Keep executed plans
+                    if hourly_plans:
+                        for plan in hourly_plans:
+                            if len(plan) >= 5 and plan[1] == hour:
+                                new_plans.append(plan)
+                                break
+                    else:
+                        # Create empty placeholder if no existing plan
+                        new_plans.append(["", hour, "self", "", 1])
+                else:
+                    # Add newly generated plans
+                    found = False
+                    for plan_data in plans_data:
+                        if plan_data['time'] == hour:
+                            hourly_plan = HourlyPlan(
+                                action=plan_data['action'],
+                                time=plan_data['time'],
+                                target=plan_data['target'],
+                                location=plan_data['location'],
+                                importance=plan_data['importance']
+                            )
+                            new_plans.append(hourly_plan.to_list())
+                            found = True
+                            break
+                    if not found:
+                        # Create default plan if no corresponding hour plan found
+                        new_plans.append(["Rest", hour, "self", "", 1])
+
+            # Save new plans (pass current_tick explicitly for correct day calculation)
+            await state_plugin.set_hourly_plans(new_plans, tick=current_tick)
+            logger.info(f"[{agent_id}][{current_tick}] Remaining plans replanning completed, total {len(new_plans)} hours")
+            return new_plans
+
+        except Exception as e:
+            logger.error(f"[{agent_id}][{current_tick}] Failed to replan remaining plans: {e}")
+            raise

--- a/examples/deduction_en/plugins/agent/reflect/BasicReflectPlugin.py
+++ b/examples/deduction_en/plugins/agent/reflect/BasicReflectPlugin.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, Optional, List
+from typing import Dict, Any, Optional, List, Tuple
 from agentkernel_distributed.types.schemas.message import Message
 from agentkernel_distributed.mas.agent.base.plugin_base import ReflectPlugin
 from agentkernel_distributed.toolkit.logger import get_logger
@@ -22,15 +22,26 @@ class BasicReflectPlugin(ReflectPlugin):
 
     async def execute(self, current_tick: int) -> None:
         """
-        Perform a lightweight survival check every tick, and a full reflection logic every 12 ticks
+        Perform a lightweight survival check every tick.
+        Full reflection logic (summary, task check, adjustment) every 12 ticks.
+        Replan check every tick based on last tick's short-term memory.
         """
         # Perform lightweight survival check every tick (read-only short-term memory)
         if await self._check_life_status_lightweight(current_tick):
             return
 
-        # Check if it's a reflection cycle (executed every 12 ticks)
+        # Check if replanning is needed based on last tick's memory (every tick)
+        # Only check if there are remaining hours (not the last hour of the day)
+        current_hour = current_tick % 12
+        if current_hour < 11:  # Only replan if there are remaining hours in the day
+            should_replan, replan_reason = await self._should_replan(current_tick)
+            if should_replan:
+                logger.info(f"[{self.agent_id}][{current_tick}] Detected need to replan: {replan_reason}")
+                await self._replan_remaining(current_tick, replan_reason)
+
+        # Full reflection logic every 12 ticks
         if (current_tick + 1) % 12 == 0:
-            logger.info(f"[{self.agent_id}][{current_tick}] Starting reflection logic")
+            logger.info(f"[{self.agent_id}][{current_tick}] Starting full reflection logic")
 
             try:
                 # 1. Summarize short-term memory
@@ -47,9 +58,9 @@ class BasicReflectPlugin(ReflectPlugin):
                 # 4. Dynamically adjust LongTask (if not completed)
                 await self._adjust_long_task(current_tick)
 
-                logger.info(f"[{self.agent_id}][{current_tick}] Reflection logic execution completed")
+                logger.info(f"[{self.agent_id}][{current_tick}] Full reflection logic execution completed")
             except Exception as e:
-                logger.error(f"[{self.agent_id}][{current_tick}] Error executing reflection logic: {e}")
+                logger.error(f"[{self.agent_id}][{current_tick}] Error executing full reflection logic: {e}")
 
     async def reflect_task(self, task: LongTask, type: str, current_tick: int = None) -> None:
         """
@@ -482,3 +493,135 @@ Please judge and give result:"""
 
         except Exception as e:
             logger.error(f"[{self.agent_id}][{current_tick}] Error adjusting LongTask: {e}")
+
+    async def _should_replan(self, current_tick: int) -> Tuple[bool, str]:
+        """
+        Determine if remaining hourly plans need to be replanned
+
+        Returns:
+            Tuple[bool, str]: (whether needs replanning, reason)
+        """
+        try:
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+
+            # Get current LongTask
+            long_task = await state_plugin.get_long_task()
+            if not long_task:
+                return (False, "No long-term task")
+
+            # Get short-term memory from last tick
+            short_memories = await state_plugin.get_short_term_memory()
+            if not short_memories:
+                return (False, "No short-term memory")
+
+            last_memory = short_memories[-1]
+            last_memory_text = last_memory.get('content', str(last_memory))
+
+            # Get current hour and remaining plans
+            current_hour = current_tick % 12
+            remaining_hours = 12 - current_hour - 1
+
+            # Get remaining unexecuted hourly plans
+            current_day = (current_tick // 12) + 1
+            hourly_plans = await state_plugin.get_hourly_plans(day=current_day)
+
+            remaining_plans = []
+            if hourly_plans:
+                for plan in hourly_plans:
+                    if len(plan) >= 5 and plan[1] > current_hour:
+                        remaining_plans.append(plan)
+
+            remaining_plans_text = "\n".join([
+                f"- Hour {plan[1]}: {plan[0]} (target:{plan[2]}, location:{plan[3]})"
+                for plan in remaining_plans
+            ]) if remaining_plans else "No remaining plans"
+
+            # Build Prompt
+            prompt = f"""You are an agent plan evaluation assistant. Based on recent memory, determine whether the remaining time needs to be replanned.
+
+Current long-term task: {long_task}
+
+Last tick event: {last_memory_text}
+
+Current time: Day {current_day}, Hour {current_hour} (remaining {remaining_hours} hours)
+
+Remaining unexecuted plans:
+{remaining_plans_text}
+
+Evaluation criteria:
+1. Did any major change occur in the last tick (e.g., character death, task completion, unexpected event)?
+2. Has the current task become invalid or deviated?
+3. Is it reasonable to continue executing the original plan?
+
+Please return (conclusion only):
+- Needs replanning: "Needs Replanning | reason"
+- No replanning needed: "No Replanning | reason"
+"""
+
+            result = await self.model.chat(prompt)
+            result = result.strip()
+
+            logger.info(f"[{self.agent_id}][{current_tick}] Plan replanning decision result: {result}")
+
+            if "Needs Replanning" in result or "需要重新规划" in result:
+                parts = result.split('|')
+                reason = parts[1].strip() if len(parts) > 1 else "Major change occurred"
+                return (True, reason)
+            else:
+                return (False, result)
+
+        except Exception as e:
+            logger.error(f"[{self.agent_id}][{current_tick}] Error determining replanning: {e}")
+            return (False, f"Error: {str(e)}")
+
+    async def _replan_remaining(self, current_tick: int, reason: str) -> None:
+        """
+        Regenerate remaining hourly plans
+
+        Args:
+            current_tick: current tick
+            reason: replanning reason
+        """
+        try:
+            state_component = self._component.agent.get_component("state")
+            state_plugin = state_component.get_plugin()
+
+            profile_component = self._component.agent.get_component("profile")
+            profile_plugin = profile_component.get_plugin()
+            profile = profile_plugin.get_agent_profile()
+
+            # Get current LongTask
+            long_task = await state_plugin.get_long_task()
+
+            # Calculate current hour and remaining hours
+            current_hour = current_tick % 12
+            current_day = (current_tick // 12) + 1
+
+            logger.info(f"[{self.agent_id}][{current_tick}] Starting to regenerate remaining plans, current hour {current_hour}, remaining {12-current_hour-1} hours")
+
+            # Call PlanPlugin to regenerate remaining plans
+            plan_component = self._component.agent.get_component("plan")
+            if plan_component:
+                plan_plugin = plan_component.get_plugin()
+                # Call the new replan method
+                await plan_plugin.replan_remaining_plans(
+                    agent_id=self.agent_id,
+                    current_tick=current_tick,
+                    profile=profile,
+                    long_task=long_task,
+                    start_hour=current_hour + 1
+                )
+                logger.info(f"[{self.agent_id}][{current_tick}] Remaining plans replanning completed")
+                # Record the replan event so the frontend can highlight changed plan items
+                await state_plugin.add_replan_event(
+                    tick=current_tick,
+                    reason=reason,
+                    day=current_day,
+                    from_hour=current_hour + 1,
+                )
+            else:
+                logger.warning(f"[{self.agent_id}][{current_tick}] Cannot get plan component")
+
+        except Exception as e:
+            logger.error(f"[{self.agent_id}][{current_tick}] Error replanning remaining plans: {e}")

--- a/examples/deduction_en/plugins/agent/state/BasicStatePlugin.py
+++ b/examples/deduction_en/plugins/agent/state/BasicStatePlugin.py
@@ -50,6 +50,9 @@ class BasicStatePlugin(StatePlugin):
         elif isinstance(self.state_data['hourly_plans'], list):
             old_list = self.state_data['hourly_plans']
             self.state_data['hourly_plans'] = {1: old_list}
+        # Initialize replan log (records each time plans are dynamically changed mid-day)
+        if 'replan_log' not in self.state_data:
+            self.state_data['replan_log'] = []
 
     async def init(self) -> None:
         """Initialize StatePlugin, get agent_id from component"""
@@ -116,20 +119,50 @@ class BasicStatePlugin(StatePlugin):
         """
         return await self.get_state('long_task')
 
-    async def set_hourly_plans(self, hourly_plans: list) -> None:
+    async def set_hourly_plans(self, hourly_plans: list, tick: int = None) -> None:
         """
         Set 12 hourly plans, stored by day
 
         Args:
             hourly_plans: 12 hourly plans list, format is List[List[Any]]
+            tick: The tick to use for day calculation. If None, uses self.current_tick.
+                  Pass current_tick explicitly to avoid timing issues since the state
+                  component executes after plan/invoke in the component order.
         """
-        day = (self.current_tick // 12) + 1
+        effective_tick = tick if tick is not None else self.current_tick
+        day = (effective_tick // 12) + 1
         
         if 'hourly_plans' not in self.state_data or not isinstance(self.state_data['hourly_plans'], dict):
             self.state_data['hourly_plans'] = {}
             
         self.state_data['hourly_plans'][day] = hourly_plans
         logger.info(f"[{self.agent_id}][{self.current_tick}] Day {day} 12 hourly plans set, total {len(hourly_plans)} hours")
+
+    async def add_replan_event(self, tick: int, reason: str, day: int, from_hour: int) -> None:
+        """
+        Record a mid-day replan event for frontend display.
+
+        Args:
+            tick: The tick at which replanning occurred
+            reason: Why replanning was triggered
+            day: Which day's plans were changed
+            from_hour: Starting hour of the newly generated plans
+        """
+        if 'replan_log' not in self.state_data:
+            self.state_data['replan_log'] = []
+        self.state_data['replan_log'].append({
+            'tick': tick,
+            'reason': reason,
+            'day': day,
+            'from_hour': from_hour,
+        })
+        logger.info(f"[{self.agent_id}][{tick}] Replan event recorded: day {day}, from hour {from_hour}, reason: {reason}")
+
+    async def get_replan_log(self) -> list:
+        """
+        Return the full list of replan events.
+        """
+        return self.state_data.get('replan_log', [])
 
     async def get_hourly_plans(self, day: int = None) -> Optional[Any]:
         """

--- a/examples/deduction_en/plugins/agent/state/component.py
+++ b/examples/deduction_en/plugins/agent/state/component.py
@@ -68,3 +68,21 @@ class BasicStateComponent(StateComponent):
         if not self._plugin:
             return []
         return await self._plugin.get_short_term_memory()
+
+    async def get_hourly_plans(self, day: int = None) -> Any:
+        """Delegate get_hourly_plans to plugin."""
+        if not self._plugin:
+            return None
+        return await self._plugin.get_hourly_plans(day)
+
+    async def add_replan_event(self, tick: int, reason: str, day: int, from_hour: int) -> None:
+        """Delegate add_replan_event to plugin."""
+        if not self._plugin:
+            return
+        return await self._plugin.add_replan_event(tick, reason, day, from_hour)
+
+    async def get_replan_log(self) -> List[Any]:
+        """Delegate get_replan_log to plugin."""
+        if not self._plugin:
+            return []
+        return await self._plugin.get_replan_log()

--- a/examples/deduction_en/run_simulation.py
+++ b/examples/deduction_en/run_simulation.py
@@ -224,7 +224,7 @@ async def main():
         logger.info(f'【System】Simulation finished.')
 
         # ===== Step4 : Split logs by character =====
-        from examples.deduction_en.scripts.split_logs_by_character import process_log_directory
+        from examples.deduction_en.map.scripts.split_logs_by_character import process_log_directory
         log_dir = Path(project_path) / "logs"
         output_dir = log_dir / "character"
         logger.info(f'【System】Splitting logs by character...')


### PR DESCRIPTION
- Add _should_replan/_replan_remaining in ReflectPlugin to detect and replan major events.
- Add replan_remaining_plans in PlanPlugin to regenerate plans from a given hour.
- Add replan_log state tracking and expose it via PodManager.
- Update frontend to display replaced plans with strikethrough and reason.
- Fix split_logs_by_character import path (scripts -> map/scripts).
- Increase max_ticks to 100.