### PR TITLE
Remove committed API key

### DIFF
--- a/examples/deduction/configs/models_config.yaml
+++ b/examples/deduction/configs/models_config.yaml
@@ -1,6 +1,6 @@
 - name: OpenAIProvider
-  model: qwen3.5-flash
-  api_key: sk-244e6910ba754fb6aeb942da88054e16
-  base_url: https://dashscope.aliyuncs.com/compatible-mode/v1
+  model: your-model-name
+  api_key: your-api-key
+  base_url: your-base-url
   capabilities:
   - chat


### PR DESCRIPTION
This removes a committed API key from `examples/deduction/configs/models_config.yaml`
and replaces it with placeholder values.

Changes:
- replace the committed `api_key` with `your-api-key`
- replace the committed model and base URL with placeholders
- keep the config shape unchanged for local setup

Note:
The leaked DashScope key should be rotated or deleted immediately in the provider console.
