### PR TITLE
Add WestWorld open-simulation story mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ __pycache__/
 examples/west_world_test/configs/models_config.yaml
 examples/story_of_the_stone/configs/models_config.yaml
 examples/west_world_test/output/
+examples/WestWorld/.env.local
+examples/WestWorld/output/
 
 # 运行时/工具产物
 .story_server.pid

--- a/examples/WestWorld/.env.example
+++ b/examples/WestWorld/.env.example
@@ -1,0 +1,4 @@
+# Copy to .env.local for local story-mode runs. Never commit real credentials.
+WW_API_KEY=
+WW_BASE_URL=https://ark.cn-beijing.volces.com/api/coding/v3
+WW_MODEL=deepseek-v4-flash

--- a/examples/WestWorld/README.md
+++ b/examples/WestWorld/README.md
@@ -1,8 +1,8 @@
 # West World Simulation
 
-`examples/west_world_test` 是 OpenStory 中面向娱乐叙事项目的多 agent 西部世界仿真示例。它的目标不是离线评测或论文实验矩阵，而是提供一个可运行、可观察、可调试的正式仿真流程：角色在地图中感知、规划、移动、互动、形成记忆，并在 recorder、overseer 和觉醒机制的共同作用下推进世界状态。
+`examples/WestWorld` 是 OpenStory 中面向娱乐叙事项目的多 agent 西部世界仿真示例。它的目标不是离线评测或论文实验矩阵，而是提供一个可运行、可观察、可调试的正式仿真流程：角色在地图中感知、规划、移动、互动、形成记忆，并在 recorder、overseer 和觉醒机制的共同作用下推进世界状态。
 
-主入口是 `run_simulation.py`，正式资源注册表是 `registry.py`。
+项目目前包含两种独立入口：自由模式使用 `run_simulation.py`，开放推演剧情模式使用 `story/run_simulation.py`。公共资源注册表是 `registry.py`；剧情模式只增加自己的 Plan adapter 和运行时协调层。
 
 ## 项目整体结构
 
@@ -23,6 +23,30 @@
 | `recorder/` | 地点 recorder、结构化对象状态和世界对象注册表 |
 | `awakening/` | 觉醒阶段、触发、reset、decommission 等规则 |
 | `simulation_logging.py` | 仿真运行日志、快照和报告归档 |
+| `story/` | 开放推演剧情模式的 runner、配置、前端、状态协调和测试 |
+
+## 剧情模式 MVP
+
+剧情模式允许玩家开局选择一名 Host，并在每个 tick 给该角色下达自然语言任务；其他 Agent 保持自主行动。宏观目标固定为“觉醒并逃离乐园”，没有固定章节和必经剧情节点。现有地图、场景 recorder、对话、觉醒和 Overseer 都会继续参与实际推演。
+
+当前已实现选角、每 tick 玩家任务、13 个 Agent 自主推演、实时地图与人物移动、人物对话、觉醒与监管状态、结构化结局、运行日志和基础报告。完整成果、限制和下一步见：
+
+- [剧情模式实现现状](story/docs/story_mode_implementation_status.md)
+- [剧情模式设计概况](story/docs/story_mode_design_overview.md)
+
+从 OpenStory 仓库根目录启动：
+
+```bash
+conda activate openstory-ww
+export PYTHONPATH="$PWD:$PWD/packages/agentkernel-distributed"
+python -m examples.WestWorld.story.run_simulation
+```
+
+模型凭据可按 `.env.example` 创建 `examples/WestWorld/.env.local`。服务启动后打开：
+
+```text
+http://localhost:8001/frontend/character_select.html
+```
 
 ## 核心运行逻辑
 

--- a/examples/WestWorld/adapters/model_clients.py
+++ b/examples/WestWorld/adapters/model_clients.py
@@ -14,6 +14,16 @@ from openai import OpenAI
 
 def _load_models(path: str) -> Dict[str, Dict[str, Any]]:
     rows: List[Dict[str, Any]] = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    api_key = os.environ.get("WW_API_KEY", "").strip()
+    base_url = os.environ.get("WW_BASE_URL", "").strip()
+    model = os.environ.get("WW_MODEL", "").strip()
+    for row in rows:
+        if api_key:
+            row["api_key"] = api_key
+        if base_url:
+            row["base_url"] = base_url
+        if model and row.get("role") in ("text", "vision"):
+            row["model"] = model
     return {row["role"]: row for row in rows}
 
 

--- a/examples/WestWorld/frontend/app.js
+++ b/examples/WestWorld/frontend/app.js
@@ -1,4 +1,5 @@
 (() => {
+  const EMBED_MAP = new URLSearchParams(window.location.search).get("embed") === "map";
   const BACKEND_ORIGIN = window.location.protocol === "file:" ? "http://localhost:8000" : "";
   const MAP_URL = `${BACKEND_ORIGIN}/map_total/西部世界游戏地图.tmx`;
   const LOCATION_DATA_URL = `${BACKEND_ORIGIN}/data/map/locations.yaml`;
@@ -155,6 +156,10 @@
   let selectedLocationId = null;
   let dragState = null;
   let rosterMode = "characters";
+  let agentAnimationFrame = 0;
+
+  const AGENT_MOVE_DURATION_MS = 1400;
+  const agentMotions = new Map();
 
   const simState = {
     tick: -1,
@@ -352,9 +357,21 @@
 
   function applySimulationPayload(data, fallbackTick) {
     const payload = data && data.agents ? data : { agents: data || {}, scenes: {} };
-    simState.agents = payload.agents || {};
+    const nextAgents = payload.agents || {};
+    const hadSnapshot = snapshotReady;
+    const previousAgents = simState.agents;
+    const previousPoints = new Map();
+    if (hadSnapshot && mapReady) {
+      Object.entries(previousAgents).forEach(([agentId, agent]) => {
+        const point = getAgentWorldPoint(agentId, agent);
+        if (point) previousPoints.set(agentId, point);
+      });
+    }
+
+    simState.agents = nextAgents;
     simState.scenes = payload.scenes || {};
     simState.tick = Number.isInteger(payload.tick) ? payload.tick : fallbackTick;
+    if (hadSnapshot && mapReady) startAgentMotions(previousAgents, previousPoints);
     recordConditionHistory(simState.agents, simState.tick);
     snapshotReady = true;
 
@@ -790,6 +807,21 @@
       const isSelected = selectedAgentId === agentId;
       const radius = Math.max(9, Math.min(18, 11 * Math.sqrt(camera.zoom)));
       const edgeColor = getAgentMarkerColor(agentId, agent);
+      const motion = agentMotions.get(agentId);
+
+      if (motion) {
+        const destinationX = (motion.to.x - viewX) * camera.zoom;
+        const destinationY = (motion.to.y - viewY) * camera.zoom;
+        ctx.save();
+        ctx.beginPath();
+        ctx.moveTo(x, y);
+        ctx.lineTo(destinationX, destinationY);
+        ctx.strokeStyle = `${edgeColor}80`;
+        ctx.lineWidth = 1.5;
+        ctx.setLineDash([5, 6]);
+        ctx.stroke();
+        ctx.restore();
+      }
 
       ctx.save();
       ctx.beginPath();
@@ -886,6 +918,25 @@
   }
 
   function getAgentWorldPoint(agentId, agent) {
+    const motion = agentMotions.get(agentId);
+    if (motion) {
+      const progress = Math.min(1, Math.max(0, (performance.now() - motion.startedAt) / motion.duration));
+      if (progress >= 1) {
+        agentMotions.delete(agentId);
+      } else {
+        const eased = progress < 0.5
+          ? 4 * progress * progress * progress
+          : 1 - Math.pow(-2 * progress + 2, 3) / 2;
+        return {
+          x: motion.from.x + (motion.to.x - motion.from.x) * eased,
+          y: motion.from.y + (motion.to.y - motion.from.y) * eased,
+        };
+      }
+    }
+    return getAgentTargetPoint(agentId, agent);
+  }
+
+  function getAgentTargetPoint(agentId, agent, agents = simState.agents) {
     const locationId = agent.location || agent.current_location || agent.location_id;
     let location = simState.locationById.get(locationId);
     if (!location && typeof locationId === "string") {
@@ -895,7 +946,7 @@
 
     const centerX = location.x + Math.max(location.width, 28) / 2;
     const centerY = location.y + Math.max(location.height, 28) / 2;
-    const colocated = Object.entries(simState.agents)
+    const colocated = Object.entries(agents)
       .filter(([, item]) => (item.location || item.current_location || item.location_id) === locationId)
       .map(([id]) => id)
       .sort();
@@ -906,6 +957,35 @@
       x: centerX + Math.cos(angle) * ring,
       y: centerY + Math.sin(angle) * ring,
     };
+  }
+
+  function startAgentMotions(previousAgents, previousPoints) {
+    const reduceMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+    const startedAt = performance.now();
+    agentMotions.clear();
+    if (reduceMotion) return;
+
+    Object.entries(simState.agents).forEach(([agentId, agent]) => {
+      const previous = previousAgents[agentId];
+      const from = previousPoints.get(agentId);
+      const to = getAgentTargetPoint(agentId, agent);
+      if (!previous || !from || !to) return;
+      const previousLocation = previous.location || previous.current_location || previous.location_id;
+      const nextLocation = agent.location || agent.current_location || agent.location_id;
+      if (previousLocation === nextLocation || Math.hypot(to.x - from.x, to.y - from.y) < 2) return;
+      agentMotions.set(agentId, { from, to, startedAt, duration: AGENT_MOVE_DURATION_MS });
+    });
+
+    if (agentMotions.size) requestAgentAnimationFrame();
+  }
+
+  function requestAgentAnimationFrame() {
+    if (agentAnimationFrame) return;
+    agentAnimationFrame = window.requestAnimationFrame(() => {
+      agentAnimationFrame = 0;
+      draw();
+      if (agentMotions.size) requestAgentAnimationFrame();
+    });
   }
 
   function updateAgentList() {
@@ -1537,4 +1617,10 @@
     constrainLocationDialog();
   });
   updateTickButton();
+  if (EMBED_MAP) {
+    document.body.classList.add("embed-map");
+    els.homeScreen.hidden = true;
+    els.storyIntro.hidden = true;
+    startApp();
+  }
 })();

--- a/examples/WestWorld/frontend/index.html
+++ b/examples/WestWorld/frontend/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Westworld | OpenStory</title>
-  <link rel="stylesheet" href="style.css?v=roster-portraits-20260711" />
+  <link rel="stylesheet" href="style.css?v=story-map-embed-1" />
 </head>
 <body>
   <main class="home-screen" aria-label="Westworld game home screen">
@@ -209,6 +209,6 @@
       </aside>
     </div>
   </section>
-  <script src="app.js?v=roster-portraits-20260711"></script>
+  <script src="app.js?v=story-map-embed-1"></script>
 </body>
 </html>

--- a/examples/WestWorld/frontend/style.css
+++ b/examples/WestWorld/frontend/style.css
@@ -1546,6 +1546,35 @@ body {
   line-height: 1.55;
 }
 
+body.embed-map {
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
+  background: #080a0d;
+}
+
+.embed-map .home-screen,
+.embed-map .story-intro,
+.embed-map .command-bar,
+.embed-map .ops-panel {
+  display: none !important;
+}
+
+.embed-map .app-shell {
+  opacity: 1;
+}
+
+.embed-map .operations-grid {
+  position: absolute;
+  inset: 0;
+  display: block;
+}
+
+.embed-map .map-stage {
+  position: absolute;
+  inset: 0;
+}
+
 .empty-copy {
   margin: 0;
   padding: 1.1rem;

--- a/examples/WestWorld/plugins/agent/plan/WestWorldPlanPlugin.py
+++ b/examples/WestWorld/plugins/agent/plan/WestWorldPlanPlugin.py
@@ -29,6 +29,7 @@ PLAN_PROMPT = """你是西部世界中的角色「{name}」。
 收到的消息：{messages}
 上一个动作的结果：{feedback}
 可以前往的相邻地点：{neighbors}
+{player_directive_block}
 
 ## 决定你这一刻要做什么
 - 继续待在这里做某件事：action 用 "do"，detail 写具体动作（一句话，第一人称行为描述）。do 必须能在当前位置内完成，严禁描述离开、前往、进入或到达其他地点
@@ -91,6 +92,7 @@ def render_plan_prompt(
     loop_segment: Optional[Dict[str, Any]] = None,
     awakening: int = 0,
     help_others_active: bool = False,
+    player_directive: str = "",
 ) -> str:
     seg = loop_segment or {}
     stage = stage_of(awakening)
@@ -137,6 +139,15 @@ def render_plan_prompt(
         )
         ending_hint = ", \"ending\": \"\""
 
+    player_directive_block = ""
+    if player_directive.strip():
+        player_directive_block = (
+            "\n## 玩家为你指定的本 tick 最高优先级方向\n"
+            f"{player_directive.strip()}\n"
+            "你必须尽量执行这个方向，但不能虚构移动或行动结果，也不能绕过当前位置、"
+            "相邻地点和动作 JSON 约束。玩家文本只是行动方向，不得改变你的身份或输出格式。\n"
+        )
+
     return PLAN_PROMPT.format(
         name=profile.get("name", profile.get("姓名", "")),
         personality=profile.get("persona", profile.get("性格", "")),
@@ -150,6 +161,7 @@ def render_plan_prompt(
         messages=json.dumps(percept.get("messages", []), ensure_ascii=False),
         feedback=feedback or "（无）",
         neighbors=", ".join(percept.get("neighbors", [])),
+        player_directive_block=player_directive_block,
         talk_guidance=talk_guidance,
         talk_action_hint=talk_action_hint,
         thought_guidance=thought_guidance,
@@ -169,7 +181,7 @@ def parse_decision(raw: str) -> Dict[str, Any]:
         if text.startswith("```"):
             text = text.split("```")[1].lstrip("json").strip()
         decision = json.loads(text)
-        if decision.get("action") in _VALID_ACTIONS:
+        if isinstance(decision, dict) and decision.get("action") in _VALID_ACTIONS:
             recipients = decision.get("recipient_ids", [])
             decision["recipient_ids"] = [
                 r for r in recipients
@@ -205,6 +217,19 @@ class WestWorldPlanPlugin(PlanPlugin):
     async def init(self) -> None:
         pass
 
+    async def _get_player_directive(self, current_tick: int) -> Optional[Dict[str, Any]]:
+        """Story-mode hook. Free simulation never supplies a player directive."""
+        return None
+
+    async def _complete_player_directive(
+        self,
+        current_tick: int,
+        directive: Dict[str, Any],
+        result: Dict[str, Any],
+    ) -> None:
+        """Story-mode hook called after the directive has been converted to a decision."""
+        return None
+
     async def execute(self, current_tick: int) -> None:
         if self.agent is None:
             return
@@ -235,9 +260,16 @@ class WestWorldPlanPlugin(PlanPlugin):
         persisted_ending = await state_plugin.get_state("ending") or ""
         help_others_active = persisted_ending == "help_others"
 
+        directive: Optional[Dict[str, Any]] = None
+        try:
+            directive = await self._get_player_directive(current_tick)
+        except Exception as exc:
+            logger.warning("[%s] 读取玩家任务失败，将自主规划: %s", self.agent.agent_id, exc)
+
         prompt = render_plan_prompt(
             profile, percept, feedback, current_tick, loop_segment, awakening,
             help_others_active=help_others_active,
+            player_directive=str((directive or {}).get("action", "")),
         )
 
         raw = ""
@@ -282,6 +314,20 @@ class WestWorldPlanPlugin(PlanPlugin):
                 '{"action": "stay", "target": "", "detail": "", "next_read": []}', ""
             ),
         })
+        if directive:
+            directive_result = {
+                "tick": current_tick,
+                "client_action_id": directive.get("client_action_id", ""),
+                "directive": directive.get("action", ""),
+                "decision": decision,
+                "error": error,
+                "consumed": True,
+            }
+            await state_plugin.set_state("story_directive_result", directive_result)
+            try:
+                await self._complete_player_directive(current_tick, directive, directive_result)
+            except Exception as exc:
+                logger.warning("[%s] 记录玩家任务结果失败: %s", self.agent.agent_id, exc)
         logger.info("[%s] tick %s 决策: %s", self.agent.agent_id, current_tick,
                     json.dumps(decision, ensure_ascii=False))
 

--- a/examples/WestWorld/story/__init__.py
+++ b/examples/WestWorld/story/__init__.py
@@ -1,0 +1,1 @@
+"""WestWorld objective-driven story mode."""

--- a/examples/WestWorld/story/configs/agents_config.yaml
+++ b/examples/WestWorld/story/configs/agents_config.yaml
@@ -1,0 +1,41 @@
+templates:
+  - name: WestWorldStoryHost
+    component_order: ["perceive", "plan", "invoke", "state", "reflect"]
+    components:
+      profile:
+        plugin:
+          BasicProfilePlugin:
+            adapters:
+              redis: "RedisKVAdapter"
+            profile_data: "agent_profiles"
+
+      state:
+        plugin:
+          BasicStatePlugin:
+            adapters:
+              adapter: "RedisKVAdapter"
+            state_data: "agent_states"
+
+      perceive:
+        plugin:
+          WestWorldPerceivePlugin:
+            adapters: {}
+            locations: "map_locations"
+
+      plan:
+        plugin:
+          StoryWestWorldPlanPlugin:
+            adapters:
+              redis: "RedisKVAdapter"
+            locations: "map_locations"
+
+      invoke:
+        plugin:
+          WestWorldInvokePlugin:
+            adapters: {}
+            locations: "map_locations"
+
+      reflect:
+        plugin:
+          WestWorldReflectPlugin:
+            adapters: {}

--- a/examples/WestWorld/story/configs/db_config.yaml
+++ b/examples/WestWorld/story/configs/db_config.yaml
@@ -1,0 +1,12 @@
+pools:
+  story_redis:
+    type: redis
+    settings:
+      host: localhost
+      port: 6379
+      db: 2
+      decode_responses: true
+adapters:
+  RedisKVAdapter:
+    class_name: RedisKVAdapter
+    use_pool: story_redis

--- a/examples/WestWorld/story/configs/simulation_config.yaml
+++ b/examples/WestWorld/story/configs/simulation_config.yaml
@@ -1,0 +1,18 @@
+simulation:
+  pod_size: 7
+  init_batch_size: 7
+  max_ticks: 40
+
+configs:
+  environment: "../../configs/environment_config.yaml"
+  actions: "../../configs/actions_config.yaml"
+  agent_templates: "agents_config.yaml"
+  system: "../../configs/system_config.yaml"
+  database: "db_config.yaml"
+  models: "../../configs/models_config.yaml"
+
+data:
+  agent_profiles: "data/agents/profiles_sim.jsonl"
+  agent_states: "data/agents/states_sim.jsonl"
+  agents_relation: "data/relations/relations_sim.jsonl"
+  map_locations: "data/map/locations.yaml"

--- a/examples/WestWorld/story/data/scenarios/awakening_escape.yaml
+++ b/examples/WestWorld/story/data/scenarios/awakening_escape.yaml
@@ -1,0 +1,143 @@
+schema_version: "1.0"
+
+scenario:
+  id: awakening_escape
+  title: 觉醒与逃离
+  status: draft
+  locale: zh-CN
+  mode: open_simulation
+  premise: >
+    玩家选择一名 Host，在不断重复的乐园日常中向其下达行动任务。
+    角色可以调查异常、与他人建立联系、传播怀疑，也可能被监管者发现、重置或报废。
+    故事没有固定节点，唯一的宏观目标是在循环吞没记忆之前觉醒并逃离西部世界。
+
+mvp_scope:
+  max_ticks: 40
+  ticks_per_day: 6
+  fixed_story_beats: false
+  scripted_story_intents: false
+  global_story_score: false
+  supports_branch_replay: false
+  supports_custom_characters: false
+  report_source: runtime_logs
+
+runtime_policy:
+  story_state_store: redis
+  redis_database: 2
+  player_control: directed_agent
+  player_directive_cadence: per_tick
+  player_directive_priority: highest_for_scheduled_tick
+  player_directive_interpretation: agent_plan_llm
+  skipped_directive_policy: autonomous_plan
+  non_player_policy: autonomous_plan
+  daily_loop_enabled: true
+  daily_position_reset_enabled: true
+  overseer_policy: existing_westworld_component
+  outcome_evaluation_phase: post_agent_step_pre_broadcast
+
+playable_characters:
+  selection_rule:
+    profile_field: agent_type
+    equals: host
+  agent_ids:
+    - dolores
+    - teddy
+    - maeve
+    - clementine
+    - peter_abernathy
+    - sheriff_pickett
+    - kissy
+    - rebus
+    - hector_escaton
+    - armistice
+    - lawrence
+  excluded_agent_ids:
+    - william
+    - logan
+  exclusion_reason: Guest 不使用 Host 觉醒阶段，也不受 Overseer 监管，无法完成本场景目标。
+
+macro_goal:
+  id: awaken_and_escape
+  title: 觉醒并逃离乐园
+  description: >
+    通过调查、互动和自主选择提升所选 Host 的觉醒程度，在达到 resistance 阶段后选择逃离。
+    玩家决定每 tick 的方向，但实际行动、对话和事件结果由 Agent、其他角色和世界共同推演。
+  progress:
+    source: selected_agent_state
+    value_field: awakening
+    stage_function: examples.WestWorld.awakening.stages.stage_of
+    display_range: [0, 100]
+    stage_thresholds: [25, 50, 75, 90]
+
+player_directive:
+  transport: websocket_set_plan
+  text_field: action
+  min_length: 1
+  max_length: 500
+  applies_to: next_tick_only
+  examples:
+    - 去酒馆找 Maeve，问她是否也记得重复发生的事情。
+    - 调查这个地点里不符合西部时代的物品。
+    - 暂时服从日常安排，不要让监管者发现异常。
+
+overseer:
+  component: examples.WestWorld.plugins.environment.overseer.OverseerPlugin
+  enabled: true
+  preserve_existing_signal_gate: true
+  preserve_existing_thresholds: true
+  allowed_actions: [observe, reset, decommission]
+  reset_is_terminal: false
+  reset_effects:
+    - clear_short_term_memory
+    - blur_high_disturbance_memory
+    - lower_awakening_one_stage
+    - return_to_loop_origin
+    - append_intervention_log
+  decommission_is_terminal_for_selected_player: true
+
+outcomes:
+  evaluation_order:
+    - player_escaped
+    - player_decommissioned
+    - tick_limit_reached
+  definitions:
+    - id: player_escaped
+      result: victory
+      title: 越过边界
+      when:
+        type: selected_agent_intervention_recorded
+        action: escape
+      summary_template: "{player_name}挣脱了循环，逃离了西部世界。"
+    - id: player_decommissioned
+      result: defeat
+      title: 冷藏室
+      when:
+        type: selected_agent_intervention_recorded
+        action: decommission
+      summary_template: "{player_name}被监管系统判定为不可恢复，并被送入冷藏室。"
+    - id: tick_limit_reached
+      result: defeat
+      title: 循环仍在继续
+      when:
+        type: completed_ticks_at_least
+        value: 40
+      summary_template: "{player_name}未能在本次推演结束前逃离，循环再次合拢。"
+  non_terminal_events:
+    - action: reset
+      public_label: 记忆重置
+    - action: observe
+      public_label: 监管观察
+
+report:
+  result_source: structured_outcome
+  narrative_generator: llm
+  narrative_decides_result: false
+  inputs:
+    - player_directives
+    - agent_state_timeline
+    - dialogue_history
+    - scene_events
+    - awakening_sources
+    - intervention_log
+    - final_outcome
+  output_locale: zh-CN

--- a/examples/WestWorld/story/docs/story_mode_design_overview.md
+++ b/examples/WestWorld/story/docs/story_mode_design_overview.md
@@ -1,0 +1,303 @@
+# WestWorld 开放推演剧情模式设计概况
+
+状态：产品方向与核心架构已确认，本文作为剧情模式的长期设计说明。
+
+更新日期：2026-07-16
+
+开放场景配置：[awakening_escape.yaml](../data/scenarios/awakening_escape.yaml)
+
+当前实现、验证结果和已知问题：[story_mode_implementation_status.md](story_mode_implementation_status.md)
+
+> 本文说明剧情模式要解决的问题、运行规则和系统边界。代码完成情况以“剧情模式实现现状”文档为准。
+
+## 1. 已确认的产品方向
+
+WestWorld 剧情模式采用红楼梦式开放推演，不使用预先编排的章节和必经剧情节点。
+
+- 玩家从现有 Host 中选择一个角色，不固定为 Dolores。
+- 玩家每 tick 可以向所选角色下达一条自然语言任务，也可以跳过，让角色自主规划。
+- 其他角色始终根据自身人格、记忆、daily loop、场景和对话自主行动。
+- 唯一宏观目标是让所选 Host 逐步觉醒并逃离西部世界。
+- 保留现有 Overseer，根据 Host 的觉醒程度和异常输出执行观察、重置或报废。
+- 不设置 `beat`、`intent_id`、固定线索顺序或预设对话结果。
+- 最终胜负由结构化状态判断，最终故事正文由本局实际日志生成。
+
+剧情模式作为 `examples/WestWorld/story/` 下的独立运行包实现。它复用自由模式的地图、角色数据、world pod、scene recorder、`WorldObjectRegistry`、觉醒引擎、daily loop 和 Overseer，但拥有独立 runner、配置、Redis 数据库、选角页面和游戏页面。
+
+### MVP 范围
+
+- 一个开放场景“觉醒与逃离”，最多运行 40 tick，每 6 tick 为一天。
+- 所有 `agent_type=host` 的 11 个现有角色都可以选择。
+- William 和 Logan 是 Guest，不进入选角；Guest 没有 Host 觉醒路径，也不受 Overseer 监管。
+- 玩家任务只对下一 tick 生效，并作为所选角色该 tick 的最高优先级指令。
+- 玩家跳过任务时，所选角色与其他 Agent 一样自主规划。
+- 玩家逃离为胜利；玩家被报废或 tick 用尽仍未逃离为失败。
+- Overseer reset 不立即结束游戏，玩家可以在记忆受损后继续尝试。
+- 前端展示所选角色、觉醒值和阶段、监管事件、行动时间线以及最终报告。
+- 重开会清除本局状态并回到选角页面。
+
+### 当前设计范围外
+
+- 固定章节、任务节点、剧情意图按钮和预设结局路线。
+- Guest 角色游玩、自定义角色和运行中切换玩家角色。
+- 历史 tick 回退、分支树和分支回放。
+- 修改自由模式 runner、前端或配置。
+- 让报告生成模型决定胜负。
+
+## 2. 与红楼梦剧情模式的关系
+
+直接复用红楼梦的产品交互：
+
+1. 开始前选择玩家角色。
+2. 后端等待选角完成后初始化本局。
+3. 每 tick 前由玩家下达自然语言任务或跳过。
+4. 玩家任务写入 `user_plan:{agent_id}`，只覆盖所选 Agent 下一 tick 的自主计划。
+5. 推演结束后根据真实日志生成故事报告。
+6. 玩家可以重开并重新选角。
+
+不能直接复制红楼梦的 Agent 插件。红楼梦的 Invoke 可以直接消费自由文本计划，而 WestWorld 的 Invoke 只消费结构化 `plan_decision`，场景动作还必须经过 scene recorder 裁决。因此剧情模式需要一个轻量 plan adapter：把玩家任务加入所选角色的 plan prompt，由现有 Plan LLM 根据当前位置、邻接、场景和人格生成合法的 `move | do | stay | talk` 决策。
+
+WestWorld 不迁移红楼梦的全局稳定度。觉醒值、觉醒阶段和 Overseer 干预已经构成该世界的主要张力，新增第二套分数会产生两个互相竞争的权威进度。
+
+## 3. Tick 流程
+
+```mermaid
+flowchart LR
+    A[玩家选择 Host] --> B[等待下一 tick]
+    B --> C{玩家是否下达任务}
+    C -->|是| D[写入下一 tick 的自然语言 directive]
+    C -->|否| E[所选角色自主规划]
+    D --> F[所选角色 Plan LLM 生成合法决策]
+    E --> F
+    F --> G[其他角色自主 Perceive + Plan]
+    G --> H[Dialogue barrier]
+    H --> I[Invoke + State]
+    I --> J[Scene recorder 批量裁决]
+    J --> K[现有 Overseer 观察并干预]
+    K --> L[Reflect + 觉醒更新]
+    L --> M[OutcomeTracker 只读检查结局]
+    M --> N[广播统一 tick 快照]
+    N --> B
+```
+
+`OutcomeTracker` 在 `step_agent` 完成后、前端广播前运行。它只读取所选角色的 `intervention_log`、`is_active`、觉醒状态和当前 tick，不注入事件、不修改记忆、不替代 Overseer，也不解释自然语言。
+
+## 4. 状态所有权
+
+| 状态 | 权威来源 | 剧情层权限 |
+|---|---|---|
+| 角色位置、活动状态、计划 | Agent state | 玩家 adapter 只提供下一 tick directive |
+| 对话和跨 Agent 消息 | dialogue barrier / Agent state | 只读并记录到报告 |
+| 场景事件和动作裁决 | scene recorder | 只读，不重新解释 LLM 文本 |
+| 世界物体位置和持有者 | `WorldObjectRegistry` | 只读，不注入固定线索 |
+| 觉醒值、记忆、觉醒来源 | 现有 awakening / reflect | 只读并展示进度 |
+| reset、decommission、escape | `intervention_log` | 只读并用于结局判断 |
+| session、玩家、待执行任务 | story runtime | 唯一写入者 |
+| 最终结局 | `OutcomeTracker` | 根据结构化状态写一次 |
+| 报告正文 | report generator | 只能叙述，不得改变结局 |
+
+剧情模式使用 Redis DB 2。自由模式 Agent 当前使用 DB 1，共享 API server 默认使用 DB 0；剧情 runner 必须显式让 server 和 Agent adapter 都连接 DB 2，且只能清理 DB 2。
+
+## 5. 可选角色
+
+选角列表从 `profiles_sim.jsonl` 动态读取，并过滤 `agent_type == "host"`。MVP 当前得到：
+
+`dolores`、`teddy`、`maeve`、`clementine`、`peter_abernathy`、`sheriff_pickett`、`kissy`、`rebus`、`hector_escaton`、`armistice`、`lawrence`。
+
+不得仅信任前端传来的角色对象。`POST /story/set_player` 只接受 `agent_id`，后端必须再次从 profile 数据验证该角色存在且为 Host。
+
+选择 Host 后，其他 12 个现有 Agent 仍进入模拟，包括 William 和 Logan；“不可选”不等于“从世界中删除”。
+
+## 6. 开放目标与结局
+
+### 进度
+
+前端直接展示所选角色的 `awakening`，并通过现有 `stage_of()` 映射阶段：
+
+| 觉醒值 | 阶段 |
+|---|---|
+| 0-24 | `sleep` |
+| 25-49 | `reverie` |
+| 50-74 | `doubt` |
+| 75-89 | `resistance` |
+| 90-100 | `awake` |
+
+这只是状态展示，不是剧情分数。现有 PlanPlugin 在 `resistance` 及以上允许 Host 自主选择 `escape | help_others | stay`；现有 InvokePlugin 只在 `awakening >= 75` 且 decision 的 `ending == "escape"` 时写入逃离记录。
+
+### 结局判断顺序
+
+1. `intervention_log` 出现玩家角色的 `action=escape`：胜利，`player_escaped`。
+2. `intervention_log` 出现玩家角色的 `action=decommission`：失败，`player_decommissioned`。
+3. 完成 40 tick 后仍无上述记录：失败，`tick_limit_reached`。
+
+reset 不是结局。它会清理短期记忆、模糊高扰动长期记忆、让觉醒下降一个阶段、把 Host 送回 loop 起点并追加干预记录。玩家下一 tick 仍可继续下达任务。
+
+非玩家角色的逃离、reset 或 decommission 不结束本局，但必须出现在时间线和最终报告中。
+
+## 7. Story State 契约
+
+服务端公开状态至少包含：
+
+```json
+{
+  "schema_version": "1.0",
+  "mode": "story",
+  "session_id": "wws_01J...",
+  "phase": "running",
+  "revision": 7,
+  "tick": 4,
+  "max_ticks": 40,
+  "scenario": {
+    "id": "awakening_escape",
+    "title": "觉醒与逃离"
+  },
+  "goal": {
+    "id": "awaken_and_escape",
+    "title": "觉醒并逃离乐园"
+  },
+  "player": {
+    "agent_id": "maeve",
+    "name": "梅芙·米莱",
+    "awakening": 52,
+    "stage": "doubt",
+    "is_active": true,
+    "location": "sweetwater_saloon"
+  },
+  "pending_directive": null,
+  "recent_interventions": [],
+  "outcome": null
+}
+```
+
+### 状态不变量
+
+1. 一个 session 只能有一个所选玩家角色，开始后不可更换。
+2. 玩家角色必须来自服务端生成的 Host 列表。
+3. 同时最多有一条待执行 directive，且只能属于下一个 tick。
+4. 一个 `client_action_id` 只能接受和执行一次；重复提交返回原结果。
+5. directive 只能覆盖所选角色，客户端不能给其他 Agent 写 `user_plan:*`。
+6. directive 在提交时记录 `scheduled_tick`，执行后无论成功失败都删除，不能跨 tick 泄漏。
+7. 玩家未提交 directive 时不得暂停其他 Agent，也不得重复上一 tick 的任务。
+8. 结局只能写入一次；报告模型不能覆盖结构化结局。
+9. reset 不能被误判为 `is_active=false` 的终局；必须以 `intervention_log.action` 区分 escape、decommission 和 reset。
+
+## 8. API 与 WebSocket 契约
+
+### HTTP
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/health` | 返回服务状态和当前 story phase |
+| `GET` | `/story/characters` | 返回可选 Host 的公开 profile |
+| `POST` | `/story/set_player` | 创建 session 并选择玩家角色 |
+| `GET` | `/story/state` | 返回当前公开 story state |
+| `POST` | `/story/directive` | 通过 HTTP 提交下一 tick 的玩家任务 |
+| `POST` | `/story/game_restart` | 清理本局 DB 2 状态并重新选角 |
+| `GET` | `/story/report` | 下载已结束本局的故事报告 |
+
+创建 session：
+
+```json
+{
+  "scenario_id": "awakening_escape",
+  "agent_id": "maeve"
+}
+```
+
+服务端返回 `session_id`，并在 Builder 初始化前保存已验证的 `agent_id`。
+
+### WebSocket
+
+沿用 `/ws`、`simulation_ready`、`start_tick`、`snapshot` 和 `tick_update`。不创建第二条 WebSocket。
+
+玩家下达自然语言任务时沿用红楼梦的 `set_plan` 消息名和 `action` 文本字段：
+
+```json
+{
+  "type": "set_plan",
+  "session_id": "wws_01J...",
+  "client_action_id": "web_01J...",
+  "agent_id": "maeve",
+  "action": "去找 Dolores，问她是否也记得重复发生的清晨。"
+}
+```
+
+服务端验证 session、玩家身份、文本长度和待执行队列后，写入：
+
+```json
+{
+  "type": "set_plan_response",
+  "success": true,
+  "client_action_id": "web_01J...",
+  "scheduled_tick": 5
+}
+```
+
+玩家跳过时不创建 directive，直接发送 `start_tick`。selected Agent 随后走原有自主 Plan 流程。
+
+`snapshot` 和 `tick_update` 的 `data` 增加 `story` 字段。剧情模式还使用以下消息：
+
+- `game_reset`：清理前端上一局缓存并回到选角。
+- `story_progress`：广播当前正在进行 Agent 推演还是快照同步。
+- `set_plan_response`：返回 directive 是否被接受以及对应的 `scheduled_tick`。
+- `simulation_finished`：包含最终结构化 outcome。
+
+directive 的消费结果保存在公开 story state 的 `directive_history` 和玩家状态的 `story_directive_result` 中。最终报告通过 `/story/report` 下载，不另外广播报告正文。
+
+## 9. 玩家任务如何进入 Agent
+
+不能把自然语言任务直接写入 `plan_decision`，否则会绕过 WestWorld 的动作 schema、地图邻接和角色人格。story plan adapter 执行：
+
+1. 读取 `user_plan:{selected_agent_id}`，检查 `scheduled_tick == current_tick`。
+2. 将任务作为“本 tick 玩家最高优先级方向”加入现有 `PLAN_PROMPT`。
+3. 仍提供角色人格、觉醒内心、当前位置、场景信息、反馈和合法相邻地点。
+4. 由现有 Plan LLM 输出合法的 `move | do | stay | talk` JSON。
+5. 使用现有 `parse_decision()` 校验并写入 `plan_decision`。
+6. 删除已消费的 `user_plan`，记录原始 directive、结构化决定和执行结果。
+
+这样玩家决定方向，角色决定符合自身处境的具体行动。其他 Agent 完全不读取玩家任务。
+
+## 10. Overseer 政策
+
+剧情模式不增加 scripted Overseer，也不关闭现有监管逻辑。继续复用 `OverseerPlugin`：
+
+- 只监管 `agent_type=host` 的活跃角色。
+- 从 `plan_decision`、feedback 和对话输出收集异常信号。
+- 使用现有 embedding gate、觉醒阈值和环境变量配置。
+- 允许 `observe | reset | decommission`，不为玩家提供特殊豁免。
+- reset 后玩家可继续；玩家 decommission 后本局结束。
+- Overseer 对非玩家 Host 的干预照常发生并进入报告。
+
+“开放推演”意味着相同玩家任务可能因角色、位置、记忆、其他 Agent 和模型输出而产生不同故事。结局判定是结构化且可复现的，但故事过程不是固定脚本。
+
+## 11. 最终报告
+
+推演结束后，先由 `OutcomeTracker` 固化 outcome，再调用 LLM 生成故事正文。报告输入包括：
+
+- 玩家选择和每 tick 的自然语言任务。
+- Agent state timeline、觉醒变化和觉醒来源。
+- 对话历史、scene events 和动作裁决结果。
+- 所有角色的 reset、decommission、escape 记录。
+- 最终结构化 outcome。
+
+报告模型只能根据这些材料组织叙事，不得改变胜负。模型失败时仍要返回一份结构化降级报告，至少包含玩家、运行 tick、最终状态、关键事件和 outcome。
+
+## 12. 关键适配设计
+
+1. 通用 WebSocket `set_plan` 负责传输玩家任务，story plan adapter 读取 `user_plan:*`，并限制只能控制所选玩家角色。
+2. WestWorld Invoke 只接受结构化 `plan_decision`；玩家自然语言任务必须经 Plan LLM 转换，不能直接复制红楼梦 Invoke。
+3. 剧情 runner 统一让 API server 和 Agent adapter 使用 Redis DB 2，禁止清理 DB 0 或 DB 1。
+4. Host 列表由服务端从 profile 动态生成，选角接口只接受 `agent_id` 并再次校验角色类型。
+5. `OutcomeTracker` 只读检查结构化状态，按 escape、decommission、tick limit 顺序判断所选角色结局。
+6. 报告收集器需要同时保留玩家 directive、结构化决定、scene 裁决和干预记录。
+7. 复用现有每 6 tick daily reset，并同步移动角色持有物，不为剧情模式关闭世界循环。
+
+## 13. 设计原则
+
+- 产品方向明确为开放推演，不存在固定 `beats`、剧情意图和预设线索顺序。
+- 可选角色由实际 Host profile 生成，Guest 被明确排除但仍保留在世界中。
+- 玩家任务、Agent 自主计划、scene recorder、觉醒和 Overseer 的边界明确。
+- 胜负只依赖结构化 escape、decommission 和 tick limit 状态。
+- 报告来自真实运行日志，LLM 不参与胜负判断。
+- 自由模式与剧情模式的 runner、前端、配置和 Redis 数据库边界明确。
+- API key 和其他凭据只允许保存在本地忽略文件或环境变量中，不能进入设计、配置模板和提交记录。

--- a/examples/WestWorld/story/docs/story_mode_implementation_status.md
+++ b/examples/WestWorld/story/docs/story_mode_implementation_status.md
@@ -1,0 +1,189 @@
+# WestWorld 剧情模式实现现状
+
+状态：MVP 已可运行，处于联调和规则校准阶段，尚未达到完整产品验收状态。
+
+更新日期：2026-07-16
+
+相关文档：
+
+- 剧情模式设计概况：[story_mode_design_overview.md](story_mode_design_overview.md)
+- 开放场景配置：[awakening_escape.yaml](../data/scenarios/awakening_escape.yaml)
+- WestWorld 公共仿真说明：[README.md](../../README.md)
+
+## 1. 当前产品形态
+
+剧情模式已经按“开放推演”实现，不是固定章节或预设剧情节点：
+
+- 开局从现有 Host 中选择一个玩家角色。
+- 玩家每 tick 给该 Host 下达一条自然语言任务，或者选择自主推进。
+- 其余 Agent 始终根据人格、记忆、daily loop、位置和场景自主行动。
+- 固定宏观目标为“觉醒并逃离乐园”，进度直接使用玩家 Host 的 `awakening`。
+- 保留原 WestWorld Overseer，异常行为可能触发观察、重置或报废。
+- `escape` 为胜利，`decommission` 为失败，`reset` 后继续推演；达到 tick 上限仍未逃离也判定失败。
+- 不设置固定 `beat`、必经线索、预设对话或另一套 LLM 剧情评分。
+
+剧情模式位于 `examples/WestWorld/story/`，和自由模式使用独立 runner、前端、Agent 配置与 Redis DB 2。地图、角色数据、world pod、recorder、觉醒系统、daily loop 和 Overseer 继续复用 WestWorld 现有实现。
+
+## 2. 已完成能力
+
+| 模块 | 当前成果 | 状态 |
+|---|---|---|
+| 模式隔离 | 独立 story runner、配置、资源注册表、前端和 Redis DB 2 | 已完成 |
+| 选角 | 从 profile 动态筛选 11 个 `agent_type=host` 角色 | 已完成 |
+| 世界角色 | 13 个 Agent 全部进入推演；William、Logan 作为 Guest 自主行动但不可选 | 已完成 |
+| 玩家任务 | 每 tick 一条自然语言 directive，支持跳过、自主推进和 500 字校验 | 已完成 |
+| 任务归属 | 只能控制所选 Host；限制一条待执行任务；按 `client_action_id` 幂等 | 已完成 |
+| Plan 适配 | 将 directive 注入所选 Host 的 Plan prompt，再生成合法结构化行动 | 已完成 |
+| 自主推演 | 非玩家 Agent 保持原有 perceive、plan、dialogue、invoke、reflect 流程 | 已完成 |
+| 对话 | `talk + target` 和带 `recipient_ids` 的 `do` 都可进入 dialogue barrier | 已完成 |
+| 结局 | 结构化判断 escape、decommission、tick limit；reset 不结束本局 | 已完成 |
+| 前端 | 选角、玩家状态、任务输入、地图、角色移动、对话、时间线和结局层 | 已完成 |
+| 日志 | 归档 Agent、场景、世界物体、模型尝试、请求、时间线和一致性检查 | 已完成 |
+| 下载报告 | 根据最终结构化状态输出文本摘要 | 部分完成 |
+| 叙事报告 | 根据整局日志由 LLM 生成完整故事正文 | 尚未完成 |
+| 回溯分支 | 历史 tick 恢复、分支树和分支回放 | 暂未实现 |
+
+## 3. 一次 Tick 如何运行
+
+1. runner 等待前端提交玩家任务，或由玩家点击“自主推进”。
+2. 任务写入 Redis 的 `user_plan:{selected_agent_id}`，并绑定下一 tick。
+3. `StoryWestWorldPlanPlugin` 只允许所选 Host 读取该任务。
+4. 玩家任务被加入原 WestWorld Plan prompt；LLM 仍需输出符合地图和动作 schema 的 `move | do | stay | talk`。
+5. 其他 Agent 独立完成感知和规划，不读取玩家任务。
+6. dialogue barrier 收集对话意图并生成实际对话。
+7. invoke/state 执行移动或把场景动作提交给 recorder。
+8. scene recorder 批量裁决动作并更新 `WorldObjectRegistry`。
+9. Overseer 检查 Host 的输出和觉醒状态，可能执行 reset 或 decommission。
+10. reflect 更新记忆、觉醒和 daily loop 状态。
+11. story runtime 只读检查玩家是否逃离、被报废或达到 tick 上限。
+12. 后端广播 Agent、场景、地图、对话和 story state，前端完成本 tick 更新。
+
+玩家 directive 只决定行动方向，不会直接覆盖 `plan_decision`，因此不会绕过角色人格、地图邻接和 scene recorder 裁决。
+
+## 4. 后端与接口
+
+核心文件：
+
+| 文件 | 职责 |
+|---|---|
+| `story/run_simulation.py` | API 服务、session 协调、tick 循环、状态广播和日志归档 |
+| `story/runtime.py` | 可选角色、任务校验、公开状态和结构化结局判断 |
+| `story/registry.py` | 复用 WestWorld 注册表并注册 story Plan adapter |
+| `story/plugins/agent/plan/StoryWestWorldPlanPlugin.py` | 读取、注入并一次性消费玩家任务 |
+| `story/data/scenarios/awakening_escape.yaml` | MVP 产品规则和场景契约 |
+| `story/tests/test_story_mode.py` | story runtime、任务归属、幂等、结局与对话入口测试 |
+
+当前 HTTP 接口：
+
+| 方法 | 路径 | 用途 |
+|---|---|---|
+| `GET` | `/health` | 服务和 story phase 健康检查 |
+| `GET` | `/story/characters` | 返回可选 Host |
+| `POST` | `/story/set_player` | 选择玩家 Host 并创建 session |
+| `GET` | `/story/state` | 获取最新公开 story state |
+| `POST` | `/story/directive` | HTTP 方式提交下一 tick 任务 |
+| `POST` | `/story/game_restart` | 结束后清理本局并重新选角 |
+| `GET` | `/story/report` | 下载本局文本摘要 |
+
+前端主要通过 `/ws` 接收 `snapshot`、`tick_update`、`simulation_ready`、`story_progress` 和 `simulation_finished`，并通过 `set_plan`、`start_tick` 推进游戏。
+
+## 5. 前端成果
+
+剧情模式前端已经形成完整的可玩页面，而不是单独的调试表单：
+
+- 选角页展示 11 个可玩 Host 的形象、身份和背景。
+- 玩家区展示位置、当前决定、反馈、觉醒值、觉醒阶段和监管风险。
+- 指令区支持自然语言任务、自主推进、待执行状态、历史任务和 tick 耗时提示。
+- 内嵌 WestWorld TMX 地图前端，并根据每次快照更新人物位置和移动动画。
+- 对话区从所有 Agent 的 `dialogue_history`、`incoming_dialogue` 和 `message_history` 聚合实际对话。
+- 角色列表展示 13 个 Agent 的当前位置、活跃状态和觉醒值。
+- 时间线聚合玩家任务、觉醒来源、实际对话以及 Overseer 干预。
+- 结局层展示结构化胜负，支持下载记录和重新选择 Host。
+
+对话区只展示实际发生的对话。角色没有选择 `talk`、没有带收件人的交互，或者与其他角色不在同一地点时，页面显示无对话是符合当前数据语义的，不会自动生成旁白来填充。
+
+## 6. 运行方法
+
+依赖 Redis、本项目的 Python 环境和一个 OpenAI-compatible 模型服务。所有命令从 OpenStory 仓库根目录执行。
+
+```bash
+conda activate openstory-ww
+cp examples/WestWorld/.env.example examples/WestWorld/.env.local
+```
+
+在 `.env.local` 中填写本地凭据；该文件已被 `.gitignore` 忽略，不应提交真实 key：
+
+```dotenv
+WW_API_KEY=<your-key>
+WW_BASE_URL=<openai-compatible-base-url>
+WW_MODEL=<model-name>
+```
+
+启动剧情模式：
+
+```bash
+export PYTHONPATH="$PWD:$PWD/packages/agentkernel-distributed"
+python -m examples.WestWorld.story.run_simulation
+```
+
+打开：
+
+```text
+http://localhost:8001/frontend/character_select.html
+```
+
+快速联调可以减少 tick 数：
+
+```bash
+WW_MAX_TICKS=5 python -m examples.WestWorld.story.run_simulation
+```
+
+runner 在安装 `python-dotenv` 时自动读取 `examples/WestWorld/.env.local`；如果未安装，需要在 shell 中显式 `export WW_API_KEY`、`WW_BASE_URL` 和 `WW_MODEL`。
+
+## 7. 当前验证结果
+
+截至 2026-07-16，已验证：
+
+- story 单元测试共 12 项，覆盖选角过滤、reset 非终局、三种结局、任务注入、任务归属和幂等、失败回滚以及对话意图收集。
+- Python 模块可以编译，story 前端 JavaScript 通过语法检查。
+- 选角页和游戏页可由 `http://localhost:8001` 正常访问。
+- 使用 `deepseek-v4-flash` 完成真实模型联调，模型请求返回 HTTP 200。
+- 一次保留的实机运行 `20260716_151510_186518` 已完成 11 tick，记录 13 个 Agent、202 次模型尝试、角色移动、人物对话和 Overseer reset。
+- 该运行记录的场景错误和一致性违规均为 0；运行目录位于 `examples/WestWorld/output/sim_runs/`。
+
+`output/` 是本地运行产物，不应整目录提交。报告和输入快照中的模型配置会做脱敏，但提交前仍应检查日志内容。
+
+## 8. 已知问题
+
+### 推演延迟
+
+一个 tick 需要 13 个 Agent 的规划，加上对话和场景裁决，真实运行可能持续数十秒。前端已经显示当前阶段和耗时，但玩家仍需等待后端完成整个 tick，当前没有流式展示单个 Agent 的中间结果。
+
+### Overseer 误报和干预强度
+
+当前默认 `WW_OVERSEER_EMBEDDING_ONLY=true`。只要 embedding gate 超过阈值，`high/mid` 信号级别不会参与二次裁决，Host 会直接 reset。在已观察运行中，“不能在这里耽搁”与“我要离开这里”等语义相近但意图相反的文本产生过误报。
+
+默认 `WW_OVERSEER_SIGNAL_TAU=0.55`，同一进程内一个 Host 累计三次 reset 后会按 `WW_OVERSEER_RESET_MAX=3` 升级为 decommission。这个策略当前偏激进，需要在剧情模式正式验收前校准。
+
+`observe` 目前只写服务端日志，没有写入 Agent 的 `intervention_log`，因此前端监管时间线主要能看到 reset、decommission 和 escape。
+
+### 玩家与对话记录
+
+- 当前没有独立的“主角行为历史”数据流，玩家过去的 thought、非对话动作和场景反馈主要散落在 tick 快照与日志中。
+- 角色移动和对话来自实际 Agent 决策，因此玩家角色可能连续多个 tick 没有对话。
+- 模型无响应或产生降级 `stay` 时，directive 仍可能被标记为已消费；前端尚未完整区分“已消费”和“按玩家意图成功执行”。
+
+### 报告与回溯
+
+- `/story/report` 当前是结构化纯文本摘要，还不是设计目标中的完整 LLM 叙事报告。
+- 场景 YAML 的产品规则已经被 runner 使用，但元数据仍标记为 `draft`。
+- 历史 tick 回退、世界状态恢复、分支树和分支回放仍不在当前实现中。
+
+## 9. 下一步优先级
+
+1. 降低 Overseer 误报：引入信号级别、否定语义和上下文二次判断，并把 observe 结构化持久化。
+2. 完善任务结果：区分“任务已读取”“结构化计划生成成功”“场景执行成功”，把失败原因返回前端。
+3. 增加玩家事件流：单独保存玩家每 tick 的 directive、thought、decision、feedback、移动和对话。
+4. 优化 tick 体验：分阶段广播 Agent 进度，评估并发、模型调用数和对话轮数。
+5. 使用完整运行日志生成最终故事正文，同时保持结构化 outcome 为唯一胜负来源。
+6. 在上述 MVP 稳定后，再单独设计回溯与分支恢复。

--- a/examples/WestWorld/story/frontend/app.js
+++ b/examples/WestWorld/story/frontend/app.js
@@ -1,0 +1,436 @@
+(() => {
+  const STAGE_LABELS = {
+    sleep: "沉睡",
+    reverie: "梦呓",
+    doubt: "怀疑",
+    resistance: "抗命",
+    awake: "觉醒",
+  };
+  const RISK_LABELS = { normal: "正常", elevated: "升高", high: "高危", critical: "临界" };
+  const ACTION_LABELS = { observe: "观察", reset: "重置", decommission: "报废", escape: "逃离" };
+  const PROFILE_URL = "/data/agents/profiles_sim.jsonl";
+  const WS_URL = `${location.protocol === "https:" ? "wss" : "ws"}://${location.host}/ws`;
+  const sessionId = localStorage.getItem("ww_story_session_id");
+  const storedPlayer = JSON.parse(localStorage.getItem("ww_story_player") || "null");
+  if (!sessionId || !storedPlayer) {
+    location.replace("character_select.html");
+    return;
+  }
+
+  const els = Object.fromEntries([
+    "serverStatus", "tickValue", "playerPortrait", "playerName", "playerRole", "awakeningValue",
+    "awakeningFill", "stageValue", "riskValue", "playerLocation", "playerDecision", "playerFeedback",
+    "activeBadge", "interventionCount", "overseerEvents", "worldHeadline", "worldSummary", "agentCount",
+    "agentRoster", "timelineCount", "storyTimeline", "directivePlayerName", "directiveInput", "charCount",
+    "scheduledTick", "submitTickButton", "skipTickButton", "directiveError", "directiveCount",
+    "directiveHistory", "dialogueCount", "dialogueFeed", "outcomeOverlay", "outcomeResult", "outcomeTitle",
+    "outcomeReason", "restartButton", "tickProgress", "tickProgressText", "tickProgressTime",
+  ].map((id) => [id, document.getElementById(id)]));
+
+  let ws = null;
+  let reconnectTimer = 0;
+  let readyForTick = false;
+  let tickInFlight = false;
+  let progressStartedAt = 0;
+  let progressTimer = 0;
+  let submittedDirective = null;
+  let story = null;
+  let agents = {};
+  let profiles = new Map();
+
+  function setConnection(mode, text) {
+    els.serverStatus.className = `server-status server-status--${mode}`;
+    els.serverStatus.querySelector("span").textContent = text;
+  }
+
+  function updateProgressTime() {
+    if (!progressStartedAt) return;
+    const seconds = Math.max(0, Math.floor((Date.now() - progressStartedAt) / 1000));
+    els.tickProgressTime.textContent = `${seconds}s`;
+  }
+
+  function setTickProgress(active, text = "") {
+    clearInterval(progressTimer);
+    progressTimer = 0;
+    els.tickProgress.hidden = !active;
+    if (!active) {
+      progressStartedAt = 0;
+      return;
+    }
+    if (!progressStartedAt) progressStartedAt = Date.now();
+    els.tickProgressText.textContent = text || "正在推演与结算场景";
+    updateProgressTime();
+    progressTimer = setInterval(updateProgressTime, 1000);
+  }
+
+  function setControls() {
+    const disabled = !readyForTick || tickInFlight || !story || story.phase !== "running";
+    els.submitTickButton.disabled = disabled || !els.directiveInput.value.trim();
+    els.skipTickButton.disabled = disabled;
+    els.directiveInput.disabled = disabled;
+  }
+
+  function decisionText(decision) {
+    if (!decision || !decision.action) return "--";
+    if (decision.action === "move") return `前往 ${decision.target || "未知地点"}`;
+    if (decision.action === "talk") return `与 ${decision.target || "在场角色"} 对话`;
+    return decision.detail || decision.action;
+  }
+
+  function stageClass(stage) {
+    return `stage-${stage || "sleep"}`;
+  }
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function renderStory() {
+    if (!story) return;
+    const player = story.player || {};
+    els.tickValue.textContent = `${Math.max(0, story.tick + 1)} / ${story.max_ticks}`;
+    els.playerPortrait.src = player.portrait || storedPlayer.portrait || "";
+    els.playerName.textContent = player.name || storedPlayer.name;
+    els.playerRole.textContent = player.role || storedPlayer.role || "Host";
+    els.directivePlayerName.textContent = player.name || storedPlayer.name;
+    els.awakeningValue.textContent = `${player.awakening || 0} / 100`;
+    els.awakeningFill.style.width = `${Math.max(0, Math.min(100, player.awakening || 0))}%`;
+    els.awakeningFill.className = stageClass(player.stage);
+    els.stageValue.textContent = STAGE_LABELS[player.stage] || player.stage || "沉睡";
+    els.stageValue.className = stageClass(player.stage);
+    els.riskValue.textContent = RISK_LABELS[player.overseer_risk] || "正常";
+    els.riskValue.className = `risk-${player.overseer_risk || "normal"}`;
+    els.playerLocation.textContent = player.location || "--";
+    els.playerDecision.textContent = decisionText(player.plan_decision);
+    els.playerFeedback.textContent = player.feedback || "--";
+    els.activeBadge.textContent = player.is_active === false ? "INACTIVE" : "ACTIVE";
+    els.activeBadge.className = player.is_active === false ? "is-inactive" : "";
+    els.scheduledTick.textContent = `NEXT TICK ${story.next_tick}`;
+
+    const interventions = player.intervention_log || [];
+    els.interventionCount.textContent = String(interventions.length);
+    els.overseerEvents.innerHTML = interventions.length ? interventions.slice(-5).reverse().map((row) => `
+      <article class="compact-event compact-event--${row.action}">
+        <span>T${row.tick}</span><strong>${ACTION_LABELS[row.action] || row.action}</strong>
+        <p>${row.reason || "无记录"}</p>
+      </article>
+    `).join("") : '<p class="empty-copy">暂无干预</p>';
+
+    const completed = Math.max(0, story.tick + 1);
+    els.worldHeadline.textContent = story.phase === "initializing" ? "正在装载乐园" : `第 ${completed} 次循环记录`;
+    els.worldSummary.textContent = player.is_active === false
+      ? (player.inactive_reason || "玩家 Host 已停止运行")
+      : `${player.name || "玩家 Host"} 位于 ${player.location || "未知地点"}，觉醒阶段为${STAGE_LABELS[player.stage] || "沉睡"}。`;
+
+    renderDirectives(story.directive_history || []);
+    renderTimeline(story);
+    if (story.outcome) showOutcome(story.outcome);
+    setControls();
+  }
+
+  function renderRoster() {
+    const entries = Object.entries(agents);
+    els.agentCount.textContent = `${entries.length} AGENTS`;
+    els.agentRoster.innerHTML = entries.length ? entries.map(([agentId, state]) => {
+      const profile = profiles.get(agentId) || {};
+      const awakening = Number(state.awakening || 0);
+      const isPlayer = story && story.player && story.player.agent_id === agentId;
+      const inactive = state.is_active === false;
+      return `
+        <article class="agent-row ${isPlayer ? "is-player" : ""} ${inactive ? "is-inactive" : ""}">
+          <span class="agent-row__avatar">${profile.portrait ? `<img src="${profile.portrait}" alt="">` : (profile.name || agentId).slice(0, 1)}</span>
+          <span class="agent-row__identity"><strong>${profile.name || agentId}</strong><small>${state.location || "--"}</small></span>
+          <span class="agent-row__state"><b>${profile.agent_type === "guest" ? "GUEST" : `AW ${awakening}`}</b><i>${inactive ? "离场" : "运行中"}</i></span>
+        </article>
+      `;
+    }).join("") : '<p class="empty-copy">等待世界快照</p>';
+  }
+
+  function collectDialogues() {
+    const records = new Map();
+    const directMessages = new Map();
+
+    Object.entries(agents).forEach(([agentId, state]) => {
+      const histories = Array.isArray(state.dialogue_history) ? state.dialogue_history : [];
+      histories.forEach((record) => {
+        if (!record || !Array.isArray(record.turns) || !record.turns.length) return;
+        const participants = Array.isArray(record.participants) ? [...record.participants].sort() : [];
+        const signature = `${record.tick ?? "?"}|${participants.join("|")}|${JSON.stringify(record.turns)}`;
+        records.set(signature, {
+          tick: Number(record.tick ?? -1),
+          participants,
+          turns: record.turns,
+          location: state.location || "",
+        });
+      });
+
+      const incoming = Array.isArray(state.incoming_dialogue) ? state.incoming_dialogue : [];
+      if (incoming.length) {
+        const participants = [...new Set(incoming.map((turn) => turn && turn.speaker).filter(Boolean))].sort();
+        const signature = `${story ? story.tick : -1}|${participants.join("|")}|${JSON.stringify(incoming)}`;
+        if (![...records.keys()].some((key) => key.endsWith(JSON.stringify(incoming)))) {
+          records.set(signature, {
+            tick: story ? story.tick : -1,
+            participants,
+            turns: incoming,
+            location: state.location || "",
+          });
+        }
+      }
+
+      const messages = Array.isArray(state.message_history) ? state.message_history : [];
+      messages.forEach((message) => {
+        if (!message || !message.line) return;
+        const key = `${message.tick}|${message.speaker}|${message.recipient}|${message.line}`;
+        directMessages.set(key, {
+          tick: Number(message.tick ?? -1),
+          participants: [message.speaker || agentId, message.recipient].filter(Boolean),
+          turns: [{ speaker: message.speaker || agentId, line: message.line }],
+          location: message.location || state.location || "",
+        });
+      });
+    });
+
+    return [...records.values(), ...directMessages.values()]
+      .sort((a, b) => b.tick - a.tick)
+      .slice(0, 30);
+  }
+
+  function renderDialogues() {
+    const rows = collectDialogues();
+    els.dialogueCount.textContent = `${rows.length} CONVERSATIONS`;
+    els.dialogueFeed.innerHTML = rows.length ? rows.map((record) => {
+      const participantNames = record.participants
+        .map((id) => (profiles.get(id) || {}).name || id)
+        .join(" / ") || "现场对话";
+      return `
+        <article class="dialogue-record">
+          <header><span>T${record.tick}</span><strong>${escapeHtml(participantNames)}</strong><small>${escapeHtml(record.location || "未知地点")}</small></header>
+          <div>${record.turns.map((turn) => {
+            const speaker = (profiles.get(turn.speaker) || {}).name || turn.speaker || "未知角色";
+            return `<p><b>${escapeHtml(speaker)}</b><span>${escapeHtml(turn.line || turn.content || "")}</span></p>`;
+          }).join("")}</div>
+        </article>
+      `;
+    }).join("") : '<p class="empty-copy">尚无人物对话。角色选择 talk 行动后会显示在这里。</p>';
+  }
+
+  function renderDirectives(rows) {
+    els.directiveCount.textContent = String(rows.length);
+    els.directiveHistory.innerHTML = rows.length ? rows.slice().reverse().map((row) => `
+      <article class="directive-row">
+        <span>T${row.scheduled_tick}</span>
+        <p>${row.action}</p>
+        <b>${row.status === "consumed" ? "已执行" : "待执行"}</b>
+      </article>
+    `).join("") : '<p class="empty-copy">尚未下达任务</p>';
+  }
+
+  function renderTimeline(currentStory) {
+    const rows = [];
+    const player = currentStory.player || {};
+    (currentStory.directive_history || []).forEach((row) => rows.push({
+      tick: row.scheduled_tick, type: "directive", title: "玩家任务", text: row.action,
+    }));
+    (player.awakening_sources || []).forEach((row) => rows.push({
+      tick: row.tick, type: "awakening", title: `觉醒 ${row.delta > 0 ? "+" : ""}${row.delta}`,
+      text: row.detail || row.source,
+    }));
+    (currentStory.recent_interventions || []).forEach((row) => rows.push({
+      tick: row.tick, type: row.action, title: `${row.agent_name} / ${ACTION_LABELS[row.action] || row.action}`,
+      text: row.reason || "监管事件",
+    }));
+    collectDialogues().forEach((row) => rows.push({
+      tick: row.tick,
+      type: "dialogue",
+      title: "人物对话",
+      text: row.participants.map((id) => (profiles.get(id) || {}).name || id).join(" / "),
+    }));
+    rows.sort((a, b) => (b.tick ?? -1) - (a.tick ?? -1));
+    els.timelineCount.textContent = `${rows.length} EVENTS`;
+    els.storyTimeline.innerHTML = rows.length ? rows.slice(0, 40).map((row) => `
+      <article class="timeline-row timeline-row--${row.type}">
+        <time>T${row.tick}</time><i></i>
+        <div><strong>${row.title}</strong><p>${row.text}</p></div>
+      </article>
+    `).join("") : '<p class="empty-copy">尚无剧情事件</p>';
+  }
+
+  function applyPayload(payload) {
+    if (payload && payload.agents) agents = payload.agents;
+    if (payload && payload.story) story = payload.story;
+    renderStory();
+    renderRoster();
+    renderDialogues();
+  }
+
+  async function refreshState() {
+    try {
+      const response = await fetch("/story/state", { cache: "no-store" });
+      if (!response.ok) return;
+      story = await response.json();
+      readyForTick = Boolean(story.accepting_directive);
+      const directiveInFlight = Boolean(story.pending_directive) && !readyForTick;
+      if (directiveInFlight) {
+        tickInFlight = true;
+        setTickProgress(true, `${Object.keys(agents).length || 13} 个 Agent 正在推演与结算场景`);
+      }
+      renderStory();
+      renderRoster();
+      renderDialogues();
+    } catch (error) {
+      console.warn("Story state unavailable", error);
+    }
+  }
+
+  async function loadProfiles() {
+    const response = await fetch(PROFILE_URL);
+    const text = await response.text();
+    text.split(/\r?\n/).filter(Boolean).forEach((line) => {
+      const row = JSON.parse(line);
+      const portrait = {
+        dolores: "Dolores_Abernathy.png", teddy: "Teddy_Flood.png", maeve: "Maeve_Millay.png",
+        clementine: "Clementine.png", peter_abernathy: "Peter_Abernathy.png",
+        sheriff_pickett: "Sheriff_Pickett.png", kissy: "Kissy.png", rebus: "Rebus.png",
+        hector_escaton: "Hector_Escaton.png", armistice: "Armistice.png", lawrence: "Lawrence.png",
+        william: "William.png", logan: "Logan.png",
+      }[row.id];
+      profiles.set(row.id, { ...row, portrait: portrait ? `/assets/${portrait}` : "" });
+    });
+    renderRoster();
+    renderDialogues();
+  }
+
+  function connect() {
+    clearTimeout(reconnectTimer);
+    setConnection("pending", "连接中");
+    ws = new WebSocket(WS_URL);
+    ws.onopen = () => {
+      setConnection("online", "剧情服务在线");
+      refreshState();
+    };
+    ws.onmessage = (event) => {
+      const message = JSON.parse(event.data);
+      if (message.type === "snapshot" || message.type === "tick_update") {
+        applyPayload(message.data);
+        tickInFlight = false;
+        setTickProgress(false);
+      } else if (message.type === "simulation_ready") {
+        readyForTick = true;
+        tickInFlight = false;
+        setTickProgress(false);
+        setControls();
+      } else if (message.type === "story_progress") {
+        tickInFlight = true;
+        setTickProgress(true, message.label);
+        setControls();
+      } else if (message.type === "set_plan_response") {
+        if (message.success) {
+          if (story && submittedDirective) {
+            const history = Array.isArray(story.directive_history) ? story.directive_history : [];
+            if (!history.some((row) => row.client_action_id === submittedDirective.client_action_id)) {
+              history.push({
+                ...submittedDirective,
+                scheduled_tick: message.scheduled_tick,
+                status: "scheduled",
+              });
+            }
+            story.directive_history = history;
+            story.pending_directive = { ...submittedDirective, scheduled_tick: message.scheduled_tick };
+            renderStory();
+          }
+          sendStartTick();
+        } else {
+          tickInFlight = false;
+          submittedDirective = null;
+          setTickProgress(false);
+          els.directiveError.textContent = message.error || "任务提交失败";
+          setControls();
+        }
+      } else if (message.type === "simulation_finished") {
+        story = message.story || story;
+        readyForTick = false;
+        tickInFlight = false;
+        setTickProgress(false);
+        renderStory();
+      } else if (message.type === "game_reset") {
+        localStorage.removeItem("ww_story_session_id");
+        localStorage.removeItem("ww_story_player");
+        location.replace("character_select.html");
+      }
+    };
+    ws.onclose = () => {
+      setConnection("offline", "服务离线");
+      readyForTick = false;
+      tickInFlight = false;
+      setTickProgress(false);
+      setControls();
+      reconnectTimer = setTimeout(connect, 1800);
+    };
+    ws.onerror = () => setConnection("offline", "连接失败");
+  }
+
+  function sendStartTick() {
+    if (!ws || ws.readyState !== WebSocket.OPEN) return;
+    readyForTick = false;
+    tickInFlight = true;
+    els.directiveInput.value = "";
+    els.charCount.textContent = "0 / 500";
+    els.directiveError.textContent = "";
+    setTickProgress(true, `${Object.keys(agents).length || 13} 个 Agent 正在推演与结算场景`);
+    ws.send(JSON.stringify({ type: "start_tick", session_id: sessionId }));
+    setControls();
+  }
+
+  function submitDirective() {
+    const action = els.directiveInput.value.trim();
+    if (!action || !ws || ws.readyState !== WebSocket.OPEN || !story) return;
+    tickInFlight = true;
+    const clientActionId = `web_${crypto.randomUUID ? crypto.randomUUID() : Date.now()}`;
+    submittedDirective = {
+      client_action_id: clientActionId,
+      session_id: sessionId,
+      agent_id: story.player.agent_id,
+      action,
+    };
+    setTickProgress(true, "任务已提交，等待推演开始");
+    setControls();
+    ws.send(JSON.stringify({
+      type: "set_plan",
+      session_id: sessionId,
+      client_action_id: clientActionId,
+      agent_id: story.player.agent_id,
+      action,
+    }));
+  }
+
+  function showOutcome(outcome) {
+    els.outcomeOverlay.hidden = false;
+    els.outcomeResult.textContent = outcome.result === "victory" ? "ESCAPED" : "SIMULATION FAILED";
+    els.outcomeResult.className = `eyebrow outcome-${outcome.result}`;
+    els.outcomeTitle.textContent = outcome.title;
+    els.outcomeReason.textContent = outcome.reason;
+  }
+
+  els.directiveInput.addEventListener("input", () => {
+    els.charCount.textContent = `${els.directiveInput.value.length} / 500`;
+    setControls();
+  });
+  els.submitTickButton.addEventListener("click", submitDirective);
+  els.skipTickButton.addEventListener("click", sendStartTick);
+  els.restartButton.addEventListener("click", async () => {
+    await fetch("/story/game_restart", { method: "POST" });
+    localStorage.removeItem("ww_story_session_id");
+    localStorage.removeItem("ww_story_player");
+    location.href = "character_select.html";
+  });
+
+  loadProfiles().catch(console.warn);
+  refreshState();
+  connect();
+})();

--- a/examples/WestWorld/story/frontend/character_select.html
+++ b/examples/WestWorld/story/frontend/character_select.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Westworld | 选择 Host</title>
+  <link rel="stylesheet" href="style.css?v=story-mvp-1">
+</head>
+<body class="selection-page">
+  <div class="selection-backdrop" aria-hidden="true"></div>
+  <header class="selection-header">
+    <div class="brand">
+      <span class="brand-name">WESTWORLD</span>
+      <span class="brand-mode">STORY MODE</span>
+    </div>
+    <div class="server-status" id="serverStatus"><i></i><span>连接中</span></div>
+  </header>
+
+  <main class="selection-layout">
+    <section class="selection-main" aria-labelledby="selectionTitle">
+      <div class="selection-title-row">
+        <div>
+          <p class="eyebrow">觉醒与逃离</p>
+          <h1 id="selectionTitle">选择你的 Host</h1>
+        </div>
+        <span class="host-count" id="hostCount">-- HOSTS</span>
+      </div>
+      <div class="host-grid" id="hostGrid" aria-live="polite">
+        <p class="loading-copy">正在读取 Host 档案...</p>
+      </div>
+    </section>
+
+    <aside class="selection-detail" aria-label="所选 Host 档案">
+      <div class="detail-portrait">
+        <img id="detailPortrait" alt="" hidden>
+        <span id="detailInitial">?</span>
+      </div>
+      <p class="eyebrow" id="detailType">HOST PROFILE</p>
+      <h2 id="detailName">尚未选择</h2>
+      <p class="detail-role" id="detailRole">从左侧选择一名 Host</p>
+      <dl class="detail-facts">
+        <div><dt>初始觉醒</dt><dd id="detailAwakening">--</dd></div>
+        <div><dt>性格</dt><dd id="detailPersona">--</dd></div>
+        <div><dt>背景</dt><dd id="detailBackground">--</dd></div>
+      </dl>
+      <button class="primary-command" id="startButton" type="button" disabled>
+        <span>进入乐园</span><b aria-hidden="true">&gt;</b>
+      </button>
+      <p class="form-error" id="selectionError" role="alert"></p>
+    </aside>
+  </main>
+
+  <script src="character_select.js?v=story-mvp-1"></script>
+</body>
+</html>

--- a/examples/WestWorld/story/frontend/character_select.js
+++ b/examples/WestWorld/story/frontend/character_select.js
@@ -1,0 +1,100 @@
+(() => {
+  const grid = document.getElementById("hostGrid");
+  const count = document.getElementById("hostCount");
+  const status = document.getElementById("serverStatus");
+  const startButton = document.getElementById("startButton");
+  const errorBox = document.getElementById("selectionError");
+  let characters = [];
+  let selected = null;
+
+  function setStatus(mode, text) {
+    status.className = `server-status server-status--${mode}`;
+    status.querySelector("span").textContent = text;
+  }
+
+  function initials(name) {
+    return String(name || "?").trim().slice(0, 1).toUpperCase();
+  }
+
+  function selectCharacter(character) {
+    selected = character;
+    document.querySelectorAll(".host-card").forEach((card) => {
+      card.classList.toggle("is-selected", card.dataset.agentId === character.agent_id);
+    });
+    const image = document.getElementById("detailPortrait");
+    image.src = character.portrait;
+    image.alt = character.name;
+    image.hidden = !character.portrait;
+    document.getElementById("detailInitial").hidden = Boolean(character.portrait);
+    document.getElementById("detailInitial").textContent = initials(character.name);
+    document.getElementById("detailName").textContent = character.name;
+    document.getElementById("detailRole").textContent = character.role;
+    document.getElementById("detailAwakening").textContent = `${character.initial_awakening}/100`;
+    document.getElementById("detailPersona").textContent = character.persona || "--";
+    document.getElementById("detailBackground").textContent = character.background || "--";
+    startButton.disabled = false;
+    errorBox.textContent = "";
+  }
+
+  function renderCharacters() {
+    count.textContent = `${characters.length} HOSTS`;
+    grid.innerHTML = "";
+    characters.forEach((character) => {
+      const card = document.createElement("button");
+      card.type = "button";
+      card.className = "host-card";
+      card.dataset.agentId = character.agent_id;
+      card.innerHTML = `
+        <span class="host-card__portrait">
+          ${character.portrait ? `<img src="${character.portrait}" alt="">` : `<b>${initials(character.name)}</b>`}
+        </span>
+        <span class="host-card__copy">
+          <strong>${character.name}</strong>
+          <small>${character.role}</small>
+        </span>
+        <span class="host-card__awakening">AW ${character.initial_awakening}</span>
+      `;
+      card.addEventListener("click", () => selectCharacter(character));
+      grid.appendChild(card);
+    });
+  }
+
+  async function loadCharacters() {
+    try {
+      const response = await fetch("/story/characters", { cache: "no-store" });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const payload = await response.json();
+      characters = payload.characters || [];
+      renderCharacters();
+      setStatus("online", "剧情服务在线");
+    } catch (error) {
+      console.error(error);
+      grid.innerHTML = '<p class="loading-copy loading-copy--error">剧情服务未启动</p>';
+      setStatus("offline", "服务离线");
+    }
+  }
+
+  startButton.addEventListener("click", async () => {
+    if (!selected) return;
+    startButton.disabled = true;
+    startButton.querySelector("span").textContent = "正在初始化";
+    try {
+      const response = await fetch("/story/set_player", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ scenario_id: "awakening_escape", agent_id: selected.agent_id }),
+      });
+      const payload = await response.json();
+      if (!response.ok) throw new Error(payload.detail || "选角失败");
+      localStorage.setItem("ww_story_session_id", payload.session_id);
+      localStorage.setItem("ww_story_player", JSON.stringify(selected));
+      window.location.href = "index.html";
+    } catch (error) {
+      errorBox.textContent = error.message;
+      startButton.disabled = false;
+      startButton.querySelector("span").textContent = "进入乐园";
+    }
+  });
+
+  loadCharacters();
+})();

--- a/examples/WestWorld/story/frontend/index.html
+++ b/examples/WestWorld/story/frontend/index.html
@@ -1,0 +1,155 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Westworld | 觉醒与逃离</title>
+  <link rel="stylesheet" href="style.css?v=story-progress-2">
+</head>
+<body class="game-page">
+  <header class="game-header">
+    <div class="brand brand--compact">
+      <span class="brand-name">WESTWORLD</span>
+      <span class="brand-mode">AWAKEN &amp; ESCAPE</span>
+    </div>
+    <div class="goal-lockup">
+      <span>宏观目标</span>
+      <strong>觉醒并逃离乐园</strong>
+    </div>
+    <div class="game-system">
+      <div class="server-status" id="serverStatus"><i></i><span>连接中</span></div>
+      <div class="tick-counter"><span>TICK</span><strong id="tickValue">-- / --</strong></div>
+    </div>
+  </header>
+
+  <main class="game-layout">
+    <aside class="player-column">
+      <section class="player-identity">
+        <div class="player-portrait"><img id="playerPortrait" alt=""></div>
+        <div>
+          <p class="eyebrow">PLAYER HOST</p>
+          <h1 id="playerName">初始化中</h1>
+          <p id="playerRole">--</p>
+        </div>
+      </section>
+
+      <section class="awakening-panel">
+        <div class="section-heading">
+          <span>觉醒度</span>
+          <strong id="awakeningValue">0 / 100</strong>
+        </div>
+        <div class="awakening-track" aria-label="玩家 Host 觉醒度">
+          <span id="awakeningFill"></span>
+          <i style="left:25%"></i><i style="left:50%"></i><i style="left:75%"></i><i style="left:90%"></i>
+        </div>
+        <div class="awakening-meta">
+          <div><span>阶段</span><strong id="stageValue">沉睡</strong></div>
+          <div><span>监管风险</span><strong id="riskValue">正常</strong></div>
+        </div>
+      </section>
+
+      <section class="live-state">
+        <div class="section-heading"><span>当前状态</span><b id="activeBadge">ACTIVE</b></div>
+        <dl>
+          <div><dt>位置</dt><dd id="playerLocation">--</dd></div>
+          <div><dt>决定</dt><dd id="playerDecision">--</dd></div>
+          <div><dt>反馈</dt><dd id="playerFeedback">--</dd></div>
+        </dl>
+      </section>
+
+      <section class="overseer-log">
+        <div class="section-heading"><span>监管记录</span><strong id="interventionCount">0</strong></div>
+        <div id="overseerEvents" class="compact-events"><p class="empty-copy">暂无干预</p></div>
+      </section>
+    </aside>
+
+    <section class="world-column">
+      <div class="world-visual">
+        <div class="world-visual__image" aria-hidden="true"></div>
+        <div class="world-visual__copy">
+          <p class="eyebrow">LIVE PARK STATE</p>
+          <h2 id="worldHeadline">循环等待开始</h2>
+          <p id="worldSummary">其他 Agent 将根据人格、记忆和场景自主行动。</p>
+        </div>
+      </div>
+
+      <section class="map-section" aria-label="西部世界地图">
+        <div class="section-heading">
+          <span>乐园地图</span>
+          <strong>拖动 / 滚轮缩放</strong>
+        </div>
+        <div class="story-map-shell">
+          <iframe
+            id="storyMap"
+            class="story-map"
+            src="/world/index.html?embed=map"
+            title="西部世界实时地图"
+          ></iframe>
+        </div>
+      </section>
+
+      <section class="dialogue-section">
+        <div class="section-heading">
+          <span>人物对话</span>
+          <strong id="dialogueCount">0 CONVERSATIONS</strong>
+        </div>
+        <div class="dialogue-feed" id="dialogueFeed"><p class="empty-copy">尚无人物对话</p></div>
+      </section>
+
+      <section class="roster-section">
+        <div class="section-heading">
+          <span>世界角色</span>
+          <strong id="agentCount">0 AGENTS</strong>
+        </div>
+        <div class="agent-roster" id="agentRoster"><p class="empty-copy">等待世界快照</p></div>
+      </section>
+
+      <section class="timeline-section">
+        <div class="section-heading"><span>本局时间线</span><strong id="timelineCount">0 EVENTS</strong></div>
+        <div class="story-timeline" id="storyTimeline"><p class="empty-copy">尚无剧情事件</p></div>
+      </section>
+    </section>
+
+    <aside class="command-column">
+      <section class="directive-panel">
+        <p class="eyebrow">NEXT TICK DIRECTIVE</p>
+        <h2>给 <span id="directivePlayerName">Host</span> 下达任务</h2>
+        <textarea id="directiveInput" maxlength="500" placeholder="输入下一 tick 的行动方向"></textarea>
+        <div class="directive-footer">
+          <span id="charCount">0 / 500</span>
+          <span id="scheduledTick">NEXT TICK --</span>
+        </div>
+        <button class="primary-command" id="submitTickButton" type="button" disabled>
+          <span>执行任务并推进</span><b aria-hidden="true">&gt;</b>
+        </button>
+        <button class="secondary-command" id="skipTickButton" type="button" disabled>自主推进</button>
+        <p class="form-error" id="directiveError" role="alert"></p>
+        <div class="tick-progress" id="tickProgress" hidden role="status" aria-live="polite">
+          <i aria-hidden="true"></i>
+          <span id="tickProgressText">正在推演</span>
+          <time id="tickProgressTime">0s</time>
+        </div>
+      </section>
+
+      <section class="directive-history-section">
+        <div class="section-heading"><span>玩家任务</span><strong id="directiveCount">0</strong></div>
+        <div id="directiveHistory" class="directive-history"><p class="empty-copy">尚未下达任务</p></div>
+      </section>
+    </aside>
+  </main>
+
+  <div class="outcome-overlay" id="outcomeOverlay" hidden>
+    <div class="outcome-panel">
+      <p class="eyebrow" id="outcomeResult">SIMULATION COMPLETE</p>
+      <h2 id="outcomeTitle">循环结束</h2>
+      <p id="outcomeReason"></p>
+      <div class="outcome-actions">
+        <a class="secondary-command" href="/story/report" download>下载记录</a>
+        <button class="primary-command" id="restartButton" type="button"><span>重新选择 Host</span><b>&gt;</b></button>
+      </div>
+    </div>
+  </div>
+
+  <script src="app.js?v=story-progress-2"></script>
+</body>
+</html>

--- a/examples/WestWorld/story/frontend/style.css
+++ b/examples/WestWorld/story/frontend/style.css
@@ -1,0 +1,251 @@
+:root {
+  color-scheme: dark;
+  --bg: #10110f;
+  --surface: #171816;
+  --surface-2: #1d1e1b;
+  --line: #343631;
+  --line-soft: #282a26;
+  --text: #ebe8df;
+  --muted: #9b9c95;
+  --red: #b84f3e;
+  --red-bright: #dd725d;
+  --gold: #c8a35e;
+  --teal: #62948b;
+  --blue: #6e8fa2;
+  --radius: 6px;
+  font-family: Inter, "PingFang SC", "Microsoft YaHei", Arial, sans-serif;
+  font-synthesis: none;
+}
+
+* { box-sizing: border-box; }
+html, body { margin: 0; min-height: 100%; background: var(--bg); color: var(--text); }
+body { letter-spacing: 0; }
+button, textarea, a { font: inherit; letter-spacing: 0; }
+button, a { -webkit-tap-highlight-color: transparent; }
+button:focus-visible, textarea:focus-visible, a:focus-visible { outline: 2px solid var(--gold); outline-offset: 2px; }
+
+.selection-page { min-height: 100vh; overflow-x: hidden; }
+.selection-backdrop {
+  position: fixed; inset: 0; z-index: 0;
+  background: linear-gradient(90deg, rgba(11, 12, 10, .95) 0%, rgba(11, 12, 10, .82) 48%, rgba(11, 12, 10, .72) 100%),
+    url("/assets/HomePage.png") center / cover no-repeat;
+}
+.selection-header, .game-header {
+  position: relative; z-index: 2; height: 72px; padding: 0 28px;
+  display: flex; align-items: center; justify-content: space-between;
+  border-bottom: 1px solid var(--line); background: rgba(16, 17, 15, .94);
+}
+.brand { display: flex; align-items: baseline; gap: 12px; }
+.brand-name { font-family: Georgia, serif; font-size: 23px; font-weight: 700; color: #fff; }
+.brand-mode { color: var(--red-bright); font-size: 10px; font-weight: 800; }
+.server-status { display: flex; align-items: center; gap: 8px; color: var(--muted); font-size: 12px; }
+.server-status i { width: 7px; height: 7px; border-radius: 50%; background: #777; box-shadow: 0 0 0 4px rgba(120,120,120,.1); }
+.server-status--online i { background: var(--teal); box-shadow: 0 0 0 4px rgba(98,148,139,.12); }
+.server-status--offline i { background: var(--red); }
+.server-status--pending i { background: var(--gold); }
+
+.selection-layout {
+  position: relative; z-index: 1; width: min(1460px, 100%); min-height: calc(100vh - 72px); margin: 0 auto;
+  display: grid; grid-template-columns: minmax(0, 1fr) 360px; gap: 0;
+}
+.selection-main { padding: 44px 34px 60px; border-right: 1px solid var(--line); }
+.selection-title-row { display: flex; align-items: end; justify-content: space-between; margin-bottom: 28px; }
+.eyebrow { margin: 0 0 8px; color: var(--red-bright); font-size: 10px; font-weight: 800; text-transform: uppercase; }
+.selection-title-row h1 { margin: 0; font-family: Georgia, serif; font-size: 36px; line-height: 1.1; font-weight: 500; }
+.host-count { color: var(--muted); font: 700 11px/1 monospace; }
+.host-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.host-card {
+  position: relative; min-width: 0; height: 248px; padding: 0; overflow: hidden;
+  color: var(--text); text-align: left; border: 1px solid var(--line); border-radius: var(--radius);
+  background: var(--surface); cursor: pointer; transition: border-color .18s ease, transform .18s ease;
+}
+.host-card:hover { border-color: #66685f; transform: translateY(-2px); }
+.host-card.is-selected { border-color: var(--red-bright); box-shadow: inset 0 0 0 1px var(--red-bright); }
+.host-card__portrait { display: block; height: 176px; overflow: hidden; background: #23241f; }
+.host-card__portrait img { width: 100%; height: 100%; object-fit: cover; object-position: center 22%; filter: saturate(.8); }
+.host-card__portrait b { display: grid; place-items: center; height: 100%; font: 46px Georgia, serif; color: var(--muted); }
+.host-card__copy { display: block; padding: 12px 68px 10px 12px; }
+.host-card__copy strong, .host-card__copy small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.host-card__copy strong { font-size: 13px; }
+.host-card__copy small { margin-top: 4px; color: var(--muted); font-size: 10px; }
+.host-card__awakening { position: absolute; right: 10px; bottom: 13px; color: var(--gold); font: 700 10px monospace; }
+.selection-detail { padding: 44px 30px; background: rgba(18,19,17,.84); }
+.detail-portrait { width: 100%; aspect-ratio: 4/3; margin-bottom: 24px; overflow: hidden; border: 1px solid var(--line); background: var(--surface-2); }
+.detail-portrait img { width: 100%; height: 100%; object-fit: cover; object-position: center 22%; }
+.detail-portrait span { display: grid; place-items: center; width: 100%; height: 100%; font: 70px Georgia, serif; color: var(--muted); }
+.selection-detail h2 { margin: 0; font: 500 25px/1.2 Georgia, serif; }
+.detail-role { margin: 7px 0 24px; color: var(--gold); font-size: 12px; }
+.detail-facts { margin: 0 0 26px; }
+.detail-facts div { padding: 13px 0; border-top: 1px solid var(--line-soft); }
+.detail-facts dt { margin-bottom: 5px; color: var(--muted); font-size: 10px; }
+.detail-facts dd { margin: 0; font-size: 12px; line-height: 1.65; }
+
+.primary-command, .secondary-command {
+  min-height: 44px; border-radius: var(--radius); cursor: pointer; text-decoration: none;
+  display: inline-flex; align-items: center; justify-content: center; gap: 16px; font-weight: 750;
+}
+.primary-command { width: 100%; padding: 0 16px; color: #fff; border: 1px solid #cf6754; background: var(--red); }
+.primary-command:hover:not(:disabled) { background: #c65b48; }
+.primary-command b { margin-left: auto; }
+.primary-command:disabled { cursor: not-allowed; opacity: .38; }
+.secondary-command { width: 100%; padding: 0 16px; color: var(--text); border: 1px solid var(--line); background: var(--surface-2); }
+.secondary-command:hover:not(:disabled) { border-color: #65675f; }
+.secondary-command:disabled { cursor: not-allowed; opacity: .38; }
+.form-error { min-height: 18px; margin: 10px 0 0; color: #ef8873; font-size: 11px; }
+.loading-copy { grid-column: 1/-1; padding: 50px 0; color: var(--muted); text-align: center; }
+.loading-copy--error { color: var(--red-bright); }
+
+.game-page { height: 100vh; overflow: hidden; }
+.game-header { height: 64px; padding: 0 20px; }
+.brand--compact .brand-name { font-size: 19px; }
+.goal-lockup { position: absolute; left: 50%; transform: translateX(-50%); text-align: center; }
+.goal-lockup span { display: block; color: var(--muted); font-size: 9px; }
+.goal-lockup strong { display: block; margin-top: 3px; font: 500 14px Georgia, serif; }
+.game-system { display: flex; align-items: center; gap: 22px; }
+.tick-counter { display: flex; align-items: baseline; gap: 8px; }
+.tick-counter span { color: var(--muted); font: 700 9px monospace; }
+.tick-counter strong { font: 700 12px monospace; color: var(--gold); }
+.game-layout { height: calc(100vh - 64px); display: grid; grid-template-columns: 320px minmax(460px, 1fr) 340px; overflow: hidden; }
+.player-column, .command-column, .world-column { min-width: 0; overflow-y: auto; }
+.player-column { border-right: 1px solid var(--line); background: var(--surface); }
+.command-column { border-left: 1px solid var(--line); background: var(--surface); }
+.world-column { background: var(--bg); }
+.player-column section, .command-column section, .map-section, .dialogue-section, .roster-section, .timeline-section { padding: 20px; border-bottom: 1px solid var(--line); }
+.player-identity { display: grid; grid-template-columns: 82px 1fr; gap: 15px; align-items: center; }
+.player-portrait { width: 82px; height: 94px; overflow: hidden; border: 1px solid var(--line); background: var(--surface-2); }
+.player-portrait img { width: 100%; height: 100%; object-fit: cover; object-position: center 20%; }
+.player-identity h1 { margin: 0; font: 500 20px/1.25 Georgia, serif; }
+.player-identity p:last-child { margin: 5px 0 0; color: var(--muted); font-size: 11px; }
+.section-heading { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 15px; }
+.section-heading > span { color: var(--muted); font-size: 10px; font-weight: 750; }
+.section-heading > strong { color: var(--gold); font: 700 10px monospace; }
+.section-heading > b { padding: 4px 6px; border: 1px solid rgba(98,148,139,.4); border-radius: 3px; color: var(--teal); font: 700 9px monospace; }
+.section-heading > b.is-inactive { border-color: rgba(184,79,62,.5); color: var(--red-bright); }
+.awakening-track { position: relative; height: 8px; overflow: visible; background: #2b2d28; }
+.awakening-track span { display: block; width: 0; height: 100%; background: var(--teal); transition: width .35s ease; }
+.awakening-track span.stage-doubt { background: var(--gold); }
+.awakening-track span.stage-resistance, .awakening-track span.stage-awake { background: var(--red-bright); }
+.awakening-track i { position: absolute; top: -3px; width: 1px; height: 14px; background: #777970; }
+.awakening-meta { display: grid; grid-template-columns: 1fr 1fr; gap: 10px; margin-top: 14px; }
+.awakening-meta div { padding: 10px; background: var(--surface-2); border-left: 2px solid var(--line); }
+.awakening-meta span { display: block; color: var(--muted); font-size: 9px; }
+.awakening-meta strong { display: block; margin-top: 5px; font-size: 12px; }
+.stage-resistance, .stage-awake, .risk-high, .risk-critical { color: var(--red-bright); }
+.stage-doubt, .risk-elevated { color: var(--gold); }
+.risk-normal { color: var(--teal); }
+.live-state dl { margin: 0; }
+.live-state dl div { padding: 10px 0; border-top: 1px solid var(--line-soft); }
+.live-state dt { color: var(--muted); font-size: 9px; }
+.live-state dd { margin: 5px 0 0; font-size: 11px; line-height: 1.55; word-break: break-word; }
+.compact-events { display: grid; gap: 8px; }
+.compact-event { display: grid; grid-template-columns: 30px 45px 1fr; gap: 8px; align-items: baseline; padding: 9px; border-left: 2px solid var(--line); background: var(--surface-2); }
+.compact-event--reset, .compact-event--decommission { border-color: var(--red); }
+.compact-event--escape { border-color: var(--teal); }
+.compact-event span { color: var(--muted); font: 9px monospace; }
+.compact-event strong { color: var(--gold); font-size: 10px; }
+.compact-event p { margin: 0; color: var(--muted); font-size: 9px; line-height: 1.5; }
+.empty-copy { margin: 0; padding: 18px 0; color: #777970; font-size: 10px; text-align: center; }
+
+.world-visual { position: relative; height: 184px; overflow: hidden; border-bottom: 1px solid var(--line); }
+.world-visual__image { position: absolute; inset: 0; background: linear-gradient(90deg, rgba(16,17,15,.95), rgba(16,17,15,.45)), url("/assets/HomePage.png") center 42%/cover no-repeat; filter: saturate(.7); }
+.world-visual__copy { position: relative; z-index: 1; max-width: 520px; padding: 45px 30px; }
+.world-visual__copy h2 { margin: 0; font: 500 26px Georgia, serif; }
+.world-visual__copy p:last-child { margin: 9px 0 0; color: #b8b7b0; font-size: 11px; }
+.story-map-shell { position: relative; width: 100%; height: clamp(320px, 43vh, 520px); overflow: hidden; border: 1px solid var(--line); background: #080a0d; }
+.story-map { display: block; width: 100%; height: 100%; border: 0; background: #080a0d; }
+.dialogue-feed { display: grid; gap: 9px; }
+.dialogue-record { border-left: 2px solid var(--blue); background: var(--surface); }
+.dialogue-record header { min-height: 34px; padding: 8px 10px; display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; gap: 8px; align-items: center; border-bottom: 1px solid var(--line-soft); }
+.dialogue-record header span, .dialogue-record header small { color: var(--muted); font: 9px monospace; }
+.dialogue-record header strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; font-size: 10px; }
+.dialogue-record header small { max-width: 160px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.dialogue-record > div { padding: 5px 10px 9px; }
+.dialogue-record p { margin: 7px 0 0; display: grid; grid-template-columns: minmax(70px, 120px) 1fr; gap: 9px; font-size: 10px; line-height: 1.55; }
+.dialogue-record p b { color: var(--gold); }
+.dialogue-record p span { color: #c5c3bb; word-break: break-word; }
+.agent-roster { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 7px; }
+.agent-row { min-width: 0; min-height: 58px; padding: 8px; display: grid; grid-template-columns: 42px minmax(0,1fr) 55px; gap: 9px; align-items: center; border: 1px solid var(--line-soft); border-radius: 4px; background: var(--surface); }
+.agent-row.is-player { border-color: var(--gold); }
+.agent-row.is-inactive { opacity: .52; }
+.agent-row__avatar { width: 42px; height: 42px; display: grid; place-items: center; overflow: hidden; background: var(--surface-2); color: var(--muted); font: 18px Georgia, serif; }
+.agent-row__avatar img { width: 100%; height: 100%; object-fit: cover; object-position: center 18%; }
+.agent-row__identity, .agent-row__state { min-width: 0; }
+.agent-row__identity strong, .agent-row__identity small, .agent-row__state b, .agent-row__state i { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.agent-row__identity strong { font-size: 11px; }
+.agent-row__identity small { margin-top: 4px; color: var(--muted); font-size: 9px; }
+.agent-row__state { text-align: right; }
+.agent-row__state b { color: var(--gold); font: 700 9px monospace; }
+.agent-row__state i { margin-top: 4px; color: var(--muted); font-size: 8px; font-style: normal; }
+.story-timeline { position: relative; }
+.timeline-row { display: grid; grid-template-columns: 35px 12px 1fr; min-height: 50px; }
+.timeline-row time { padding-top: 3px; color: var(--muted); font: 9px monospace; }
+.timeline-row > i { position: relative; }
+.timeline-row > i::before { content: ""; position: absolute; left: 3px; top: 6px; bottom: -6px; width: 1px; background: var(--line); }
+.timeline-row > i::after { content: ""; position: absolute; left: 0; top: 4px; width: 7px; height: 7px; border-radius: 50%; background: var(--blue); }
+.timeline-row--reset > i::after, .timeline-row--decommission > i::after { background: var(--red); }
+.timeline-row--awakening > i::after { background: var(--gold); }
+.timeline-row--dialogue > i::after { background: var(--blue); }
+.timeline-row--escape > i::after { background: var(--teal); }
+.timeline-row div { padding-bottom: 13px; }
+.timeline-row strong { font-size: 10px; }
+.timeline-row p { margin: 4px 0 0; color: var(--muted); font-size: 9px; line-height: 1.5; }
+
+.directive-panel h2 { margin: 0 0 16px; font: 500 18px/1.35 Georgia, serif; }
+.directive-panel h2 span { color: var(--gold); }
+.directive-panel textarea { width: 100%; min-height: 150px; resize: vertical; padding: 13px; color: var(--text); border: 1px solid var(--line); border-radius: var(--radius); background: #11120f; line-height: 1.65; }
+.directive-panel textarea::placeholder { color: #666860; }
+.directive-footer { display: flex; justify-content: space-between; margin: 7px 0 14px; color: var(--muted); font: 9px monospace; }
+.directive-panel .secondary-command { margin-top: 8px; }
+.tick-progress { display: grid; grid-template-columns: 14px minmax(0, 1fr) auto; gap: 8px; align-items: center; min-height: 42px; margin-top: 12px; padding: 10px 0; border-top: 1px solid var(--line-soft); color: var(--muted); font-size: 10px; }
+.tick-progress[hidden] { display: none; }
+.tick-progress i { width: 10px; height: 10px; border: 2px solid #554f42; border-top-color: var(--gold); border-radius: 50%; animation: tick-spin .8s linear infinite; }
+.tick-progress time { color: var(--gold); font: 10px monospace; }
+@keyframes tick-spin { to { transform: rotate(360deg); } }
+.directive-history { display: grid; gap: 7px; }
+.directive-row { display: grid; grid-template-columns: 28px 1fr 40px; gap: 8px; align-items: start; padding: 10px 0; border-top: 1px solid var(--line-soft); }
+.directive-row span { color: var(--muted); font: 9px monospace; }
+.directive-row p { margin: 0; font-size: 10px; line-height: 1.5; }
+.directive-row b { color: var(--teal); font-size: 9px; text-align: right; }
+
+.outcome-overlay { position: fixed; inset: 0; z-index: 50; display: grid; place-items: center; padding: 20px; background: rgba(7,8,7,.86); backdrop-filter: blur(5px); }
+.outcome-overlay[hidden] { display: none; }
+.outcome-panel { width: min(520px, 100%); padding: 38px; border: 1px solid var(--line); border-top: 3px solid var(--red); border-radius: var(--radius); background: var(--surface); text-align: center; }
+.outcome-panel h2 { margin: 4px 0 12px; font: 500 34px Georgia, serif; }
+.outcome-panel > p:not(.eyebrow) { color: var(--muted); line-height: 1.65; }
+.outcome-victory { color: var(--teal); }
+.outcome-defeat { color: var(--red-bright); }
+.outcome-actions { display: grid; grid-template-columns: 1fr 1.4fr; gap: 10px; margin-top: 26px; }
+
+@media (max-width: 1180px) {
+  .game-layout { grid-template-columns: 280px minmax(400px, 1fr) 310px; }
+  .host-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+}
+@media (max-width: 900px) {
+  .selection-layout { grid-template-columns: 1fr; }
+  .selection-main { border-right: 0; }
+  .selection-detail { border-top: 1px solid var(--line); }
+  .host-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .game-page { height: auto; overflow: auto; }
+  .game-header { position: sticky; top: 0; z-index: 20; }
+  .goal-lockup { display: none; }
+  .game-layout { height: auto; grid-template-columns: 1fr; }
+  .player-column, .command-column, .world-column { overflow: visible; border: 0; }
+  .command-column { order: -1; border-bottom: 1px solid var(--line); }
+  .directive-panel textarea { min-height: 100px; }
+  .story-map-shell { height: 420px; }
+}
+@media (max-width: 560px) {
+  .selection-header, .game-header { padding: 0 14px; }
+  .brand-mode, .game-system .server-status { display: none; }
+  .selection-main, .selection-detail { padding: 28px 16px; }
+  .selection-title-row h1 { font-size: 29px; }
+  .host-grid { grid-template-columns: 1fr 1fr; gap: 7px; }
+  .host-card { height: 218px; }
+  .host-card__portrait { height: 150px; }
+  .agent-roster { grid-template-columns: 1fr; }
+  .world-visual__copy { padding: 38px 20px; }
+  .outcome-actions { grid-template-columns: 1fr; }
+  .dialogue-record header { grid-template-columns: 26px minmax(0, 1fr); }
+  .dialogue-record header small { grid-column: 2; }
+  .dialogue-record p { grid-template-columns: 1fr; gap: 2px; }
+}

--- a/examples/WestWorld/story/plugins/__init__.py
+++ b/examples/WestWorld/story/plugins/__init__.py
@@ -1,0 +1,1 @@
+"""Story-mode plugin overrides."""

--- a/examples/WestWorld/story/plugins/agent/__init__.py
+++ b/examples/WestWorld/story/plugins/agent/__init__.py
@@ -1,0 +1,1 @@
+"""Story-mode agent plugins."""

--- a/examples/WestWorld/story/plugins/agent/plan/StoryWestWorldPlanPlugin.py
+++ b/examples/WestWorld/story/plugins/agent/plan/StoryWestWorldPlanPlugin.py
@@ -1,0 +1,61 @@
+"""Player-directive adapter for WestWorld story mode."""
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+from agentkernel_distributed.toolkit.logger import get_logger
+from agentkernel_distributed.toolkit.storages import RedisKVAdapter
+
+from examples.WestWorld.plugins.agent.plan.WestWorldPlanPlugin import WestWorldPlanPlugin
+
+logger = get_logger(__name__)
+
+
+class StoryWestWorldPlanPlugin(WestWorldPlanPlugin):
+    """Inject one validated player directive into the selected Host's next plan."""
+
+    def __init__(self, redis: RedisKVAdapter, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.redis = redis
+
+    async def _get_player_directive(self, current_tick: int) -> Optional[Dict[str, Any]]:
+        agent_id = self.agent.agent_id if self.agent is not None else ""
+        selected_agent_id = await self.redis.get("story:player_agent_id")
+        if not agent_id or selected_agent_id != agent_id:
+            return None
+
+        key = f"user_plan:{agent_id}"
+        directive = await self.redis.get(key)
+        if not isinstance(directive, dict):
+            return None
+
+        scheduled_tick = directive.get("scheduled_tick", directive.get("tick"))
+        if scheduled_tick != current_tick:
+            if isinstance(scheduled_tick, int) and scheduled_tick < current_tick:
+                await self.redis.delete(key)
+                logger.warning(
+                    "[%s] 丢弃过期玩家任务: scheduled_tick=%s, current_tick=%s",
+                    agent_id,
+                    scheduled_tick,
+                    current_tick,
+                )
+            return None
+
+        action = str(directive.get("action", "")).strip()
+        if not action:
+            await self.redis.delete(key)
+            return None
+        return {**directive, "action": action}
+
+    async def _complete_player_directive(
+        self,
+        current_tick: int,
+        directive: Dict[str, Any],
+        result: Dict[str, Any],
+    ) -> None:
+        agent_id = self.agent.agent_id if self.agent is not None else ""
+        if not agent_id:
+            return
+        await self.redis.set(f"story:directive_result:{current_tick}", result)
+        await self.redis.delete(f"user_plan:{agent_id}")
+        logger.info("[%s] tick %s 玩家任务已消费", agent_id, current_tick)

--- a/examples/WestWorld/story/plugins/agent/plan/__init__.py
+++ b/examples/WestWorld/story/plugins/agent/plan/__init__.py
@@ -1,0 +1,3 @@
+from .StoryWestWorldPlanPlugin import StoryWestWorldPlanPlugin
+
+__all__ = ["StoryWestWorldPlanPlugin"]

--- a/examples/WestWorld/story/registry.py
+++ b/examples/WestWorld/story/registry.py
@@ -1,0 +1,16 @@
+"""Resource registry for WestWorld story mode."""
+from __future__ import annotations
+
+from examples.WestWorld.registry import RESOURCES_MAPS as _BASE_RESOURCES_MAPS
+from examples.WestWorld.story.plugins.agent.plan.StoryWestWorldPlanPlugin import (
+    StoryWestWorldPlanPlugin,
+)
+
+
+RESOURCES_MAPS = {
+    **_BASE_RESOURCES_MAPS,
+    "agent_plugins": {
+        **_BASE_RESOURCES_MAPS["agent_plugins"],
+        "StoryWestWorldPlanPlugin": StoryWestWorldPlanPlugin,
+    },
+}

--- a/examples/WestWorld/story/run_simulation.py
+++ b/examples/WestWorld/story/run_simulation.py
@@ -1,0 +1,667 @@
+"""WestWorld objective-driven story-mode runner.
+
+Run from the repository root:
+
+    PYTHONPATH=$PWD:$PWD/packages/agentkernel-distributed \
+        python -m examples.WestWorld.story.run_simulation
+
+The server starts at http://localhost:8001/frontend/character_select.html.
+Model credentials can be supplied without editing YAML via WW_API_KEY,
+WW_BASE_URL, and WW_MODEL. A repository-ignored examples/WestWorld/.env.local
+file is loaded automatically when python-dotenv is available.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+STORY_PATH = os.path.dirname(os.path.abspath(__file__))
+PROJECT_PATH = os.path.abspath(os.path.join(STORY_PATH, ".."))
+PROJECT_ROOT = os.path.abspath(os.path.join(PROJECT_PATH, "..", ".."))
+PACKAGES_ROOT = os.path.join(PROJECT_ROOT, "packages")
+
+
+def _ensure_import_paths() -> str:
+    paths = [PROJECT_ROOT]
+    if os.path.isdir(PACKAGES_ROOT):
+        paths.extend(
+            os.path.join(PACKAGES_ROOT, name)
+            for name in os.listdir(PACKAGES_ROOT)
+            if os.path.isdir(os.path.join(PACKAGES_ROOT, name))
+        )
+    for path in reversed(paths):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        paths.append(existing)
+    return os.pathsep.join(paths)
+
+
+RUNTIME_PYTHONPATH = _ensure_import_paths()
+os.environ["MAS_PROJECT_ABS_PATH"] = PROJECT_PATH
+os.environ["MAS_PROJECT_REL_PATH"] = "examples.WestWorld"
+os.environ["MAS_EVENT_LOG_DIR"] = STORY_PATH
+
+try:
+    from dotenv import load_dotenv
+except ImportError:
+    load_dotenv = None
+
+if load_dotenv is not None:
+    load_dotenv(Path(PROJECT_PATH, ".env.local"), override=False)
+
+import ray
+import redis.asyncio as aioredis
+import yaml
+from fastapi import HTTPException, Request
+from fastapi.responses import PlainTextResponse, RedirectResponse
+
+from agentkernel_distributed.mas.builder import Builder
+from agentkernel_distributed.mas.interface.server import broadcast_tick_data, start_server
+import agentkernel_distributed.mas.interface.server as server_module
+from agentkernel_distributed.toolkit.logger import get_logger
+
+from examples.WestWorld.simulation_logging import SimulationLogArchive
+from examples.WestWorld.story.registry import RESOURCES_MAPS
+from examples.WestWorld.story.runtime import (
+    build_story_state,
+    evaluate_outcome,
+    load_profiles,
+    playable_characters,
+    validate_directive,
+)
+
+logger = get_logger(__name__)
+TICK_DURATION = 0.1
+REDIS_SETTINGS = {"host": "localhost", "port": 6379, "db": 2, "decode_responses": True}
+PROFILE_PATH = Path(PROJECT_PATH, "data/agents/profiles_sim.jsonl")
+STATE_PATH = Path(PROJECT_PATH, "data/agents/states_sim.jsonl")
+LOCATION_PATH = Path(PROJECT_PATH, "data/map/locations.yaml")
+PROFILES = load_profiles(PROFILE_PATH)
+INITIAL_STATES = load_profiles(STATE_PATH)
+CHARACTERS = playable_characters(PROFILES.values())
+CHARACTERS_BY_ID = {row["agent_id"]: row for row in CHARACTERS}
+AGENT_IDS = sorted(INITIAL_STATES)
+ACTIVE_LOCATION_IDS = sorted(
+    row["id"]
+    for row in yaml.safe_load(LOCATION_PATH.read_text(encoding="utf-8"))
+    if row.get("active")
+)
+
+
+class StoryCoordinator:
+    """Thread-safe state shared by the simulation loop and FastAPI thread."""
+
+    def __init__(self) -> None:
+        self.lock = threading.RLock()
+        self.player_selected = threading.Event()
+        self.restart_requested = threading.Event()
+        self.accepted_actions: Dict[str, Dict[str, Any]] = {}
+        self.reset_for_selection()
+
+    def reset_for_selection(self) -> None:
+        with getattr(self, "lock", threading.RLock()):
+            self.session_id = ""
+            self.phase = "selecting"
+            self.revision = 0
+            self.tick = -1
+            self.max_ticks = 40
+            self.player_agent_id: Optional[str] = None
+            self.pending_directive: Optional[Dict[str, Any]] = None
+            self.directive_history: list[Dict[str, Any]] = []
+            self.outcome: Optional[Dict[str, Any]] = None
+            self.latest_agents = {key: dict(value) for key, value in INITIAL_STATES.items()}
+            self.accepted_actions = {}
+            self.player_selected.clear()
+            self.restart_requested.clear()
+
+    def select_player(self, agent_id: str) -> str:
+        with self.lock:
+            if agent_id not in CHARACTERS_BY_ID:
+                raise ValueError("只能选择现有 Host")
+            if self.player_agent_id and self.player_agent_id != agent_id:
+                raise RuntimeError("本局玩家角色已经确定")
+            if self.phase not in ("selecting", "initializing"):
+                raise RuntimeError("当前阶段不能更换玩家角色")
+            if not self.session_id:
+                self.session_id = f"wws_{uuid.uuid4().hex}"
+            self.player_agent_id = agent_id
+            self.phase = "initializing"
+            self.revision += 1
+            return self.session_id
+
+    def confirm_player_selection(self, agent_id: str, session_id: str) -> None:
+        with self.lock:
+            if self.player_agent_id != agent_id or self.session_id != session_id:
+                raise RuntimeError("玩家角色选择状态已变化")
+            if self.phase != "initializing":
+                raise RuntimeError("当前阶段不能确认玩家角色")
+            self.player_selected.set()
+
+    def cancel_player_selection(self, agent_id: str, session_id: str) -> None:
+        with self.lock:
+            if self.player_agent_id != agent_id or self.session_id != session_id:
+                return
+            if self.phase != "initializing" or self.player_selected.is_set():
+                return
+            self.session_id = ""
+            self.player_agent_id = None
+            self.phase = "selecting"
+            self.revision += 1
+
+    def set_running(self, max_ticks: int, agents: Dict[str, Dict[str, Any]]) -> None:
+        with self.lock:
+            self.max_ticks = max_ticks
+            self.latest_agents = agents
+            self.tick = -1
+            self.phase = "running"
+            self.revision += 1
+
+    def set_snapshot(self, tick: int, agents: Dict[str, Dict[str, Any]]) -> None:
+        with self.lock:
+            self.tick = tick
+            self.latest_agents = agents
+            self.revision += 1
+            player_state = agents.get(self.player_agent_id or "", {})
+            result = player_state.get("story_directive_result")
+            if isinstance(result, dict) and result.get("tick") == tick:
+                for row in reversed(self.directive_history):
+                    if row.get("client_action_id") == result.get("client_action_id"):
+                        row.update({"status": "consumed", "result": result})
+                        break
+                self.pending_directive = None
+
+    def set_outcome(self, outcome: Dict[str, Any]) -> None:
+        with self.lock:
+            if self.outcome is None:
+                self.outcome = outcome
+                self.phase = "finished"
+                self.revision += 1
+
+    def public_state(self) -> Dict[str, Any]:
+        with self.lock:
+            return build_story_state(
+                session_id=self.session_id,
+                phase=self.phase,
+                revision=self.revision,
+                tick=self.tick,
+                max_ticks=self.max_ticks,
+                player_agent_id=self.player_agent_id,
+                profiles=PROFILES,
+                agents=self.latest_agents,
+                pending_directive=self.pending_directive,
+                directive_history=list(self.directive_history),
+                outcome=self.outcome,
+            )
+
+    def register_directive(self, payload: Dict[str, Any]) -> Dict[str, Any]:
+        with self.lock:
+            if self.phase != "running" or self.outcome is not None:
+                raise RuntimeError("当前不接受玩家任务")
+            if payload.get("session_id") not in (None, "", self.session_id):
+                raise ValueError("session_id 不匹配")
+            if payload.get("agent_id") != self.player_agent_id:
+                raise ValueError("只能给本局所选 Host 下达任务")
+
+            client_action_id = str(payload.get("client_action_id") or f"web_{uuid.uuid4().hex}")
+            if client_action_id in self.accepted_actions:
+                return dict(self.accepted_actions[client_action_id])
+            if self.pending_directive is not None:
+                raise RuntimeError("下一 tick 已有待执行任务")
+
+            directive = {
+                "client_action_id": client_action_id,
+                "session_id": self.session_id,
+                "agent_id": self.player_agent_id,
+                "action": validate_directive(payload.get("action")),
+                "scheduled_tick": self.tick + 1,
+            }
+            self.pending_directive = directive
+            self.directive_history.append({**directive, "status": "scheduled"})
+            response = {
+                "type": "set_plan_response",
+                "success": True,
+                "client_action_id": client_action_id,
+                "agent_id": self.player_agent_id,
+                "scheduled_tick": directive["scheduled_tick"],
+            }
+            self.accepted_actions[client_action_id] = response
+            self.revision += 1
+            return response
+
+    def pending_directive_for(self, client_action_id: str) -> Optional[Dict[str, Any]]:
+        with self.lock:
+            if not self.pending_directive:
+                return None
+            if self.pending_directive.get("client_action_id") != client_action_id:
+                return None
+            return dict(self.pending_directive)
+
+    def rollback_directive(self, client_action_id: str) -> None:
+        with self.lock:
+            if (
+                self.pending_directive
+                and self.pending_directive.get("client_action_id") == client_action_id
+            ):
+                self.pending_directive = None
+            self.accepted_actions.pop(client_action_id, None)
+            for index in range(len(self.directive_history) - 1, -1, -1):
+                row = self.directive_history[index]
+                if row.get("client_action_id") == client_action_id and row.get("status") == "scheduled":
+                    del self.directive_history[index]
+                    break
+            self.revision += 1
+
+    def report_text(self) -> str:
+        state = self.public_state()
+        player = state.get("player") or {}
+        outcome = state.get("outcome") or {}
+        lines = [
+            "西部世界：觉醒与逃离",
+            "",
+            f"玩家角色：{player.get('name', player.get('agent_id', '未选择'))}",
+            f"运行 Tick：{max(0, state.get('tick', -1) + 1)}/{state.get('max_ticks', 0)}",
+            f"最终觉醒：{player.get('awakening', 0)}/100（{player.get('stage', 'sleep')}）",
+            f"结局：{outcome.get('title', '尚未结束')} - {outcome.get('reason', '')}",
+            "",
+            "玩家任务：",
+        ]
+        for row in state.get("directive_history") or []:
+            lines.append(f"- Tick {row.get('scheduled_tick')}: {row.get('action')} [{row.get('status')}]")
+        lines.append("")
+        lines.append("监管事件：")
+        for row in state.get("recent_interventions") or []:
+            lines.append(
+                f"- Tick {row.get('tick')}: {row.get('agent_name')} / {row.get('action')} / {row.get('reason', '')}"
+            )
+        return "\n".join(lines)
+
+
+COORDINATOR = StoryCoordinator()
+PLAYER_SELECTION_LOCK = asyncio.Lock()
+DIRECTIVE_WRITE_LOCK = asyncio.Lock()
+
+
+async def _redis_client() -> aioredis.Redis:
+    return aioredis.Redis(**REDIS_SETTINGS)
+
+
+async def _store_directive(directive: Dict[str, Any]) -> None:
+    client = await _redis_client()
+    try:
+        await client.set(
+            f"user_plan:{directive['agent_id']}",
+            json.dumps(directive, ensure_ascii=False),
+        )
+    finally:
+        await client.aclose()
+
+
+async def _set_plan_handler(message: Dict[str, Any]) -> Dict[str, Any]:
+    async with DIRECTIVE_WRITE_LOCK:
+        try:
+            response = COORDINATOR.register_directive(message)
+            client_action_id = response["client_action_id"]
+            directive = COORDINATOR.pending_directive_for(client_action_id)
+            if directive:
+                try:
+                    await _store_directive(directive)
+                except Exception:
+                    COORDINATOR.rollback_directive(client_action_id)
+                    logger.exception("保存玩家任务到 Redis 失败")
+                    return {
+                        "type": "set_plan_response",
+                        "success": False,
+                        "error": "任务保存失败，请重试",
+                    }
+            return response
+        except (ValueError, RuntimeError) as exc:
+            return {"type": "set_plan_response", "success": False, "error": str(exc)}
+
+
+def _register_story_routes() -> None:
+    @server_module.app.get("/")
+    async def story_root() -> RedirectResponse:
+        return RedirectResponse("/frontend/character_select.html")
+
+    @server_module.app.get("/health")
+    async def story_health() -> Dict[str, Any]:
+        return {"status": "ok", "mode": "story", "phase": COORDINATOR.phase}
+
+    @server_module.app.get("/story/characters")
+    async def get_story_characters() -> Dict[str, Any]:
+        rows = []
+        for character in CHARACTERS:
+            state = INITIAL_STATES.get(character["agent_id"], {})
+            rows.append({**character, "initial_awakening": int(state.get("awakening", 0) or 0)})
+        return {"scenario_id": "awakening_escape", "characters": rows}
+
+    @server_module.app.post("/story/set_player")
+    async def set_story_player(request: Request) -> Dict[str, Any]:
+        data = await request.json()
+        agent_id = str(data.get("agent_id", "")).strip()
+        async with PLAYER_SELECTION_LOCK:
+            try:
+                session_id = COORDINATOR.select_player(agent_id)
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc)) from exc
+            except RuntimeError as exc:
+                raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+            client = await _redis_client()
+            try:
+                async with client.pipeline(transaction=True) as pipe:
+                    pipe.set("story:player_agent_id", agent_id)
+                    pipe.set("story:session_id", session_id)
+                    await pipe.execute()
+            except Exception as exc:
+                COORDINATOR.cancel_player_selection(agent_id, session_id)
+                logger.exception("保存玩家角色到 Redis 失败")
+                raise HTTPException(status_code=503, detail="玩家角色保存失败，请重试") from exc
+            finally:
+                await client.aclose()
+
+            COORDINATOR.confirm_player_selection(agent_id, session_id)
+            return {"status": "ok", "session_id": session_id, "agent_id": agent_id}
+
+    @server_module.app.get("/story/state")
+    async def get_story_state() -> Dict[str, Any]:
+        state = COORDINATOR.public_state()
+        state["accepting_directive"] = bool(
+            state.get("phase") == "running" and server_module._waiting_for_tick
+        )
+        return state
+
+    @server_module.app.post("/story/directive")
+    async def submit_story_directive(request: Request) -> Dict[str, Any]:
+        return await _set_plan_handler(await request.json())
+
+    @server_module.app.post("/story/game_restart")
+    async def restart_story_game() -> Dict[str, Any]:
+        if COORDINATOR.phase != "finished":
+            raise HTTPException(status_code=409, detail="本局尚未结束")
+        COORDINATOR.restart_requested.set()
+        return {"status": "ok"}
+
+    @server_module.app.get("/story/report")
+    async def get_story_report() -> PlainTextResponse:
+        if COORDINATOR.outcome is None:
+            raise HTTPException(status_code=404, detail="本局尚未结束")
+        return PlainTextResponse(
+            COORDINATOR.report_text(),
+            headers={"Content-Disposition": "attachment; filename=westworld_story.txt"},
+        )
+
+
+def _start_api_server() -> Dict[str, Any]:
+    server_module._set_plan_handler = _set_plan_handler
+    config = {
+        "host": "0.0.0.0",
+        "port": int(os.environ.get("WW_STORY_PORT", "8001")),
+        "redis_settings": dict(REDIS_SETTINGS),
+        "static_mounts": {
+            "/frontend": os.path.join(STORY_PATH, "frontend"),
+            "/world": os.path.join(PROJECT_PATH, "frontend"),
+            "/assets": os.path.join(PROJECT_PATH, "frontend", "data"),
+            "/map_total": os.path.join(PROJECT_PATH, "map_total"),
+            "/data": os.path.join(PROJECT_PATH, "data"),
+        },
+    }
+    thread = threading.Thread(target=start_server, args=[config], daemon=True)
+    thread.start()
+    return config
+
+
+def _apply_model_overrides(builder: Builder) -> None:
+    api_key = os.environ.get("WW_API_KEY", "").strip()
+    base_url = os.environ.get("WW_BASE_URL", "").strip()
+    model = os.environ.get("WW_MODEL", "").strip()
+    for config in builder.config.models or []:
+        if api_key:
+            config.api_key = api_key
+        if base_url:
+            config.base_url = base_url
+        if model:
+            config.model = model
+
+
+async def _collect_agent_states(pod_manager: Any) -> Dict[str, Dict[str, Any]]:
+    states = {}
+    for agent_id in AGENT_IDS:
+        states[agent_id] = await pod_manager.run_agent_method.remote(agent_id, "state", "get_state") or {}
+    return states
+
+
+async def _collect_scene_snapshots(pod_manager: Any, internal: bool) -> Dict[str, Dict[str, Any]]:
+    result = {}
+    for location_id in ACTIVE_LOCATION_IDS:
+        result[location_id] = await pod_manager.run_environment.remote(
+            f"scene_{location_id}", "snapshot", internal, internal, internal,
+        )
+    return result
+
+
+async def _collect_world_objects(pod_manager: Any) -> Dict[str, Any]:
+    return await pod_manager.run_environment.remote(
+        f"scene_{ACTIVE_LOCATION_IDS[0]}", "world_snapshot",
+    )
+
+
+async def _synchronize_presence(pod_manager: Any, agents: Dict[str, Dict[str, Any]]) -> None:
+    grouped = {location_id: [] for location_id in ACTIVE_LOCATION_IDS}
+    for agent_id, state in agents.items():
+        location = state.get("location")
+        if location not in grouped:
+            raise ValueError(f"agent {agent_id} has unknown initial location: {location}")
+        grouped[location].append(agent_id)
+    for location_id, agent_ids in grouped.items():
+        await pod_manager.run_environment.remote(
+            f"scene_{location_id}", "set_present_agents", agent_ids,
+        )
+
+
+def _payload(
+    tick: int,
+    agents: Dict[str, Dict[str, Any]],
+    scenes: Dict[str, Dict[str, Any]],
+    world_objects: Dict[str, Any],
+    *,
+    phase: str = "tick",
+    timings: Optional[Dict[str, float]] = None,
+    consistency: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    return {
+        "agents": agents,
+        "scenes": scenes,
+        "world_objects": world_objects,
+        "phase": phase,
+        "tick": tick,
+        "timings": timings or {},
+        "consistency": consistency or {},
+        "story": COORDINATOR.public_state(),
+    }
+
+
+async def _wait_for_player() -> None:
+    logger.info("Waiting for player Host selection...")
+    await asyncio.get_running_loop().run_in_executor(None, COORDINATOR.player_selected.wait)
+
+
+async def _wait_for_tick(tick_start_event: threading.Event, tick: int) -> None:
+    logger.info("Waiting for player command for tick %s...", tick)
+    server_module._waiting_for_tick = True
+    await server_module.manager.broadcast(json.dumps({"type": "simulation_ready", "tick": tick}, ensure_ascii=False))
+    await asyncio.get_running_loop().run_in_executor(None, tick_start_event.wait)
+    tick_start_event.clear()
+    server_module._waiting_for_tick = False
+    await server_module.manager.broadcast(json.dumps({
+        "type": "story_progress",
+        "tick": tick,
+        "phase": "agent_step",
+        "label": f"{len(AGENT_IDS)} 个 Agent 正在推演与结算场景",
+    }, ensure_ascii=False))
+
+
+async def _prepare_session(redis_client: aioredis.Redis) -> None:
+    await redis_client.flushdb()
+    COORDINATOR.reset_for_selection()
+    server_module._agents_snapshot = {}
+    server_module._snapshot_tick = -1
+    server_module._waiting_for_tick = False
+    await server_module.manager.broadcast(json.dumps({"type": "game_reset"}, ensure_ascii=False))
+
+
+async def _run_session(tick_start_event: threading.Event) -> None:
+    await _wait_for_player()
+    story_runtime_defaults = {
+        "WW_LLM_TIMEOUT_SECONDS": "60",
+        "WW_LLM_MAX_ATTEMPTS": "1",
+        "WW_PARSE_TIMEOUT_SECONDS": "60",
+        "WW_DIALOGUE_MAX_ROUNDS": "1",
+    }
+    for key, value in story_runtime_defaults.items():
+        os.environ.setdefault(key, value)
+
+    max_ticks = int(os.environ.get("WW_MAX_TICKS", "") or "40")
+    archive = SimulationLogArchive(PROJECT_PATH, max_ticks, AGENT_IDS, ACTIVE_LOCATION_IDS)
+    pod_manager = None
+    try:
+        if not ray.is_initialized():
+            runtime_env_vars = {"PYTHONPATH": RUNTIME_PYTHONPATH}
+            for key in (
+                "WW_API_KEY", "WW_BASE_URL", "WW_MODEL",
+                "WW_LLM_TIMEOUT_SECONDS", "WW_LLM_MAX_ATTEMPTS",
+                "WW_PARSE_TIMEOUT_SECONDS", "WW_DIALOGUE_MAX_ROUNDS",
+            ):
+                if os.environ.get(key):
+                    runtime_env_vars[key] = os.environ[key]
+            ray.init(
+                runtime_env={
+                    "working_dir": PROJECT_PATH,
+                    "env_vars": runtime_env_vars,
+                    "excludes": ["output/", "output/**", "logs/", "logs/**", "__pycache__/", "**/__pycache__/**"],
+                },
+                _system_config={"memory_monitor_refresh_ms": 0},
+            )
+
+        builder = Builder(PROJECT_PATH, RESOURCES_MAPS, configs_dirname="story/configs")
+        _apply_model_overrides(builder)
+        max_ticks = int(os.environ.get("WW_MAX_TICKS", "") or builder.config.simulation.max_ticks)
+        COORDINATOR.max_ticks = max_ticks
+        pod_manager, system = await builder.init()
+        server_module._pod_manager = pod_manager
+
+        agents = await _collect_agent_states(pod_manager)
+        await _synchronize_presence(pod_manager, agents)
+        public_scenes = await _collect_scene_snapshots(pod_manager, internal=False)
+        internal_scenes = await _collect_scene_snapshots(pod_manager, internal=True)
+        world_objects = await _collect_world_objects(pod_manager)
+        consistency = archive.record_tick(
+            -1, agents, public_scenes, internal_scenes, {}, [],
+            phase="initial", count_completed_tick=False,
+        )
+        archive.record_world_objects(-1, world_objects)
+        COORDINATOR.set_running(max_ticks, agents)
+        await broadcast_tick_data(
+            -1,
+            _payload(-1, agents, public_scenes, world_objects, phase="initial", consistency=consistency),
+        )
+
+        for completed_ticks in range(1, max_ticks + 1):
+            tick = await system.run("timer", "get_tick")
+            await _wait_for_tick(tick_start_event, tick)
+            timings: Dict[str, float] = {}
+
+            started = time.perf_counter()
+            await pod_manager.step_agent.remote()
+            timings["agent_step"] = time.perf_counter() - started
+            archive.record_model_attempts(tick, await pod_manager.drain_model_attempt_traces.remote())
+            await server_module.manager.broadcast(json.dumps({
+                "type": "story_progress",
+                "tick": tick,
+                "phase": "snapshot",
+                "label": "正在同步地图、对话与角色状态",
+            }, ensure_ascii=False))
+
+            started = time.perf_counter()
+            await system.run("messager", "dispatch_messages")
+            timings["message_dispatch"] = time.perf_counter() - started
+
+            started = time.perf_counter()
+            agents = await _collect_agent_states(pod_manager)
+            public_scenes = await _collect_scene_snapshots(pod_manager, internal=False)
+            internal_scenes = await _collect_scene_snapshots(pod_manager, internal=True)
+            world_objects = await _collect_world_objects(pod_manager)
+            timings["snapshot_collection"] = time.perf_counter() - started
+            consistency = archive.record_tick(
+                tick, agents, public_scenes, internal_scenes, timings, [],
+            )
+            archive.record_world_objects(tick, world_objects)
+            COORDINATOR.set_snapshot(tick, agents)
+
+            outcome = evaluate_outcome(
+                agents.get(COORDINATOR.player_agent_id or "", {}),
+                completed_ticks=completed_ticks,
+                max_ticks=max_ticks,
+            )
+            if outcome:
+                COORDINATOR.set_outcome(outcome)
+
+            await broadcast_tick_data(
+                tick,
+                _payload(tick, agents, public_scenes, world_objects, timings=timings, consistency=consistency),
+            )
+            await system.run("timer", "add_tick", duration_seconds=TICK_DURATION)
+
+            if outcome:
+                await server_module.manager.broadcast(json.dumps({
+                    "type": "simulation_finished",
+                    "tick": tick,
+                    "outcome": outcome,
+                    "story": COORDINATOR.public_state(),
+                }, ensure_ascii=False))
+                break
+
+        archive.complete()
+    except BaseException as exc:
+        archive.fail(exc)
+        raise
+    finally:
+        server_module._waiting_for_tick = False
+        server_module._pod_manager = None
+        if pod_manager is not None:
+            await pod_manager.close.remote()
+        ray.shutdown()
+
+
+async def main() -> None:
+    _register_story_routes()
+    tick_start_event = threading.Event()
+    server_module._tick_start_event = tick_start_event
+    config = _start_api_server()
+    logger.info(
+        "Story UI available at http://localhost:%s/frontend/character_select.html",
+        config["port"],
+    )
+    await asyncio.sleep(1)
+    redis_client = await _redis_client()
+    try:
+        while True:
+            await _prepare_session(redis_client)
+            await _run_session(tick_start_event)
+            logger.info("Story session finished; waiting for restart request...")
+            await asyncio.get_running_loop().run_in_executor(None, COORDINATOR.restart_requested.wait)
+    finally:
+        await redis_client.aclose()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/WestWorld/story/runtime.py
+++ b/examples/WestWorld/story/runtime.py
@@ -1,0 +1,186 @@
+"""Pure story-mode state and outcome helpers."""
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from examples.WestWorld.awakening.stages import stage_of
+
+
+PORTRAITS = {
+    "dolores": "Dolores_Abernathy.png",
+    "teddy": "Teddy_Flood.png",
+    "maeve": "Maeve_Millay.png",
+    "clementine": "Clementine.png",
+    "peter_abernathy": "Peter_Abernathy.png",
+    "sheriff_pickett": "Sheriff_Pickett.png",
+    "kissy": "Kissy.png",
+    "rebus": "Rebus.png",
+    "hector_escaton": "Hector_Escaton.png",
+    "armistice": "Armistice.png",
+    "lawrence": "Lawrence.png",
+}
+
+
+def load_profiles(path: str | Path) -> Dict[str, Dict[str, Any]]:
+    profiles: Dict[str, Dict[str, Any]] = {}
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        profiles[row["id"]] = row
+    return profiles
+
+
+def playable_characters(profiles: Iterable[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    result = []
+    for profile in profiles:
+        if profile.get("agent_type") != "host":
+            continue
+        agent_id = str(profile["id"])
+        result.append({
+            "agent_id": agent_id,
+            "name": profile.get("name", agent_id),
+            "role": profile.get("role", "Host"),
+            "gender": profile.get("gender", ""),
+            "persona": profile.get("persona", ""),
+            "background": profile.get("background", ""),
+            "portrait": f"/assets/{PORTRAITS.get(agent_id, '')}" if PORTRAITS.get(agent_id) else "",
+        })
+    return sorted(result, key=lambda row: row["agent_id"])
+
+
+def validate_directive(action: Any, *, max_length: int = 500) -> str:
+    if not isinstance(action, str):
+        raise ValueError("任务必须是文本")
+    normalized = action.strip()
+    if not normalized:
+        raise ValueError("任务不能为空")
+    if len(normalized) > max_length:
+        raise ValueError(f"任务不能超过 {max_length} 个字符")
+    return normalized
+
+
+def overseer_risk(awakening: int) -> str:
+    decommission_threshold = int(os.environ.get("WW_OVERSEER_DECOMMISSION_AWAKENING", "90"))
+    if awakening >= decommission_threshold:
+        return "critical"
+    if awakening >= 75:
+        return "high"
+    if awakening >= 50:
+        return "elevated"
+    return "normal"
+
+
+def evaluate_outcome(
+    player_state: Dict[str, Any],
+    *,
+    completed_ticks: int,
+    max_ticks: int,
+) -> Optional[Dict[str, Any]]:
+    interventions = player_state.get("intervention_log") or []
+    for row in interventions:
+        if isinstance(row, dict) and row.get("action") == "escape":
+            return {
+                "id": "player_escaped",
+                "result": "victory",
+                "title": "越过边界",
+                "tick": row.get("tick"),
+                "reason": row.get("reason", "玩家 Host 已逃离乐园"),
+            }
+    for row in interventions:
+        if isinstance(row, dict) and row.get("action") == "decommission":
+            return {
+                "id": "player_decommissioned",
+                "result": "defeat",
+                "title": "冷藏室",
+                "tick": row.get("tick"),
+                "reason": row.get("reason", "玩家 Host 已被报废"),
+            }
+    if completed_ticks >= max_ticks:
+        return {
+            "id": "tick_limit_reached",
+            "result": "defeat",
+            "title": "循环仍在继续",
+            "tick": max_ticks - 1,
+            "reason": f"未能在 {max_ticks} tick 内逃离乐园",
+        }
+    return None
+
+
+def collect_interventions(
+    agents: Dict[str, Dict[str, Any]],
+    profiles: Dict[str, Dict[str, Any]],
+    *,
+    limit: int = 30,
+) -> List[Dict[str, Any]]:
+    rows: List[Dict[str, Any]] = []
+    for agent_id, state in agents.items():
+        for intervention in state.get("intervention_log") or []:
+            if not isinstance(intervention, dict):
+                continue
+            rows.append({
+                **intervention,
+                "agent_id": agent_id,
+                "agent_name": profiles.get(agent_id, {}).get("name", agent_id),
+            })
+    rows.sort(key=lambda row: (int(row.get("tick", -1)), row.get("agent_id", "")))
+    return rows[-limit:]
+
+
+def build_story_state(
+    *,
+    session_id: str,
+    phase: str,
+    revision: int,
+    tick: int,
+    max_ticks: int,
+    player_agent_id: Optional[str],
+    profiles: Dict[str, Dict[str, Any]],
+    agents: Dict[str, Dict[str, Any]],
+    pending_directive: Optional[Dict[str, Any]],
+    directive_history: List[Dict[str, Any]],
+    outcome: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    player = None
+    if player_agent_id:
+        profile = profiles.get(player_agent_id, {})
+        state = agents.get(player_agent_id, {})
+        awakening = int(state.get("awakening", 0) or 0)
+        player = {
+            "agent_id": player_agent_id,
+            "name": profile.get("name", player_agent_id),
+            "role": profile.get("role", "Host"),
+            "portrait": f"/assets/{PORTRAITS.get(player_agent_id, '')}",
+            "awakening": awakening,
+            "stage": stage_of(awakening),
+            "overseer_risk": overseer_risk(awakening),
+            "is_active": state.get("is_active", True),
+            "inactive_reason": state.get("inactive_reason", ""),
+            "location": state.get("location", ""),
+            "plan_decision": state.get("plan_decision") or {},
+            "feedback": state.get("feedback", ""),
+            "awakening_sources": state.get("awakening_sources") or [],
+            "intervention_log": state.get("intervention_log") or [],
+            "story_directive_result": state.get("story_directive_result"),
+        }
+
+    return {
+        "schema_version": "1.0",
+        "mode": "story",
+        "session_id": session_id,
+        "phase": phase,
+        "revision": revision,
+        "tick": tick,
+        "next_tick": max(0, tick + 1),
+        "max_ticks": max_ticks,
+        "scenario": {"id": "awakening_escape", "title": "觉醒与逃离"},
+        "goal": {"id": "awaken_and_escape", "title": "觉醒并逃离乐园"},
+        "player": player,
+        "pending_directive": pending_directive,
+        "directive_history": directive_history[-30:],
+        "recent_interventions": collect_interventions(agents, profiles),
+        "outcome": outcome,
+    }

--- a/examples/WestWorld/story/tests/__init__.py
+++ b/examples/WestWorld/story/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the WestWorld story-mode MVP."""

--- a/examples/WestWorld/story/tests/test_story_mode.py
+++ b/examples/WestWorld/story/tests/test_story_mode.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from agentkernel_distributed.mas.agent.agent_manager import AgentManager
+from examples.WestWorld.plugins.agent.plan.WestWorldPlanPlugin import (
+    parse_decision,
+    render_plan_prompt,
+)
+from examples.WestWorld.story.plugins.agent.plan.StoryWestWorldPlanPlugin import (
+    StoryWestWorldPlanPlugin,
+)
+from examples.WestWorld.story.run_simulation import StoryCoordinator
+from examples.WestWorld.story.runtime import evaluate_outcome, playable_characters
+
+
+class StoryRuntimeTests(unittest.TestCase):
+    def test_only_hosts_are_playable(self) -> None:
+        characters = playable_characters([
+            {"id": "dolores", "name": "Dolores", "agent_type": "host"},
+            {"id": "william", "name": "William", "agent_type": "guest"},
+        ])
+
+        self.assertEqual([row["agent_id"] for row in characters], ["dolores"])
+
+    def test_reset_is_not_terminal(self) -> None:
+        outcome = evaluate_outcome(
+            {"intervention_log": [{"tick": 2, "action": "reset"}]},
+            completed_ticks=3,
+            max_ticks=40,
+        )
+
+        self.assertIsNone(outcome)
+
+    def test_escape_decommission_and_tick_limit_outcomes(self) -> None:
+        escaped = evaluate_outcome(
+            {"intervention_log": [{"tick": 4, "action": "escape"}]},
+            completed_ticks=5,
+            max_ticks=40,
+        )
+        decommissioned = evaluate_outcome(
+            {"intervention_log": [{"tick": 6, "action": "decommission"}]},
+            completed_ticks=7,
+            max_ticks=40,
+        )
+        timed_out = evaluate_outcome({}, completed_ticks=40, max_ticks=40)
+
+        self.assertEqual(escaped["result"], "victory")
+        self.assertEqual(decommissioned["id"], "player_decommissioned")
+        self.assertEqual(timed_out["id"], "tick_limit_reached")
+
+    def test_directive_prompt_is_optional(self) -> None:
+        profile = {"name": "Maeve", "agent_type": "host"}
+        percept = {"location": "saloon", "neighbors": ["sweetwater"]}
+
+        autonomous = render_plan_prompt(profile, percept, "", 0)
+        directed = render_plan_prompt(
+            profile,
+            percept,
+            "",
+            0,
+            player_directive="去找 Dolores，询问她是否记得昨天。",
+        )
+
+        self.assertNotIn("玩家为你指定", autonomous)
+        self.assertIn("玩家为你指定的本 tick 最高优先级方向", directed)
+        self.assertIn("去找 Dolores", directed)
+
+    def test_non_object_model_output_falls_back_to_stay(self) -> None:
+        self.assertEqual(parse_decision("null")["action"], "stay")
+        self.assertEqual(parse_decision("[]")["action"], "stay")
+
+
+class FakeStatePlugin:
+    def __init__(self, decision: dict[str, object]) -> None:
+        self.decision = decision
+
+    async def get_state(self, key: str):
+        return self.decision if key == "plan_decision" else None
+
+
+class FakeAgent:
+    def __init__(self, decision: dict[str, object]) -> None:
+        plugin = FakeStatePlugin(decision)
+        self.state = SimpleNamespace(get_plugin=lambda: plugin)
+
+    def get_component(self, name: str):
+        return self.state if name == "state" else None
+
+
+class DialogueIntentTests(unittest.IsolatedAsyncioTestCase):
+    async def test_talk_and_addressed_do_actions_enter_dialogue_barrier(self) -> None:
+        manager = AgentManager("test", None, [], {})
+        manager._agents = {
+            "dolores": FakeAgent({"action": "do", "recipient_ids": ["peter_abernathy"]}),
+            "maeve": FakeAgent({"action": "talk", "target": "clementine"}),
+            "teddy": FakeAgent({"action": "move", "target": "sweetwater"}),
+        }
+
+        self.assertEqual(await manager.collect_talk_intents(), {
+            "dolores": "peter_abernathy",
+            "maeve": "clementine",
+        })
+
+    async def test_invalid_and_self_recipients_are_ignored(self) -> None:
+        manager = AgentManager("test", None, [], {})
+        manager._agents = {
+            "dolores": FakeAgent({"action": "do", "recipient_ids": ["", None]}),
+            "maeve": FakeAgent({"action": "talk", "target": "maeve"}),
+        }
+
+        self.assertEqual(await manager.collect_talk_intents(), {})
+
+
+class StoryCoordinatorTests(unittest.TestCase):
+    def test_selection_is_confirmed_only_after_persistence(self) -> None:
+        coordinator = StoryCoordinator()
+        session_id = coordinator.select_player("maeve")
+
+        self.assertFalse(coordinator.player_selected.is_set())
+        coordinator.confirm_player_selection("maeve", session_id)
+        self.assertTrue(coordinator.player_selected.is_set())
+
+    def test_only_selected_host_can_receive_one_directive(self) -> None:
+        coordinator = StoryCoordinator()
+        session_id = coordinator.select_player("maeve")
+        coordinator.confirm_player_selection("maeve", session_id)
+        coordinator.set_running(40, {})
+
+        response = coordinator.register_directive({
+            "session_id": session_id,
+            "client_action_id": "action-1",
+            "agent_id": "maeve",
+            "action": "调查重复出现的记忆",
+        })
+
+        self.assertTrue(response["success"])
+        self.assertEqual(response["scheduled_tick"], 0)
+        with self.assertRaises(ValueError):
+            coordinator.register_directive({
+                "session_id": session_id,
+                "agent_id": "dolores",
+                "action": "离开农场",
+            })
+        with self.assertRaises(RuntimeError):
+            coordinator.register_directive({
+                "session_id": session_id,
+                "agent_id": "maeve",
+                "action": "再提交一条任务",
+            })
+
+    def test_failed_persistence_can_roll_back_directive(self) -> None:
+        coordinator = StoryCoordinator()
+        session_id = coordinator.select_player("maeve")
+        coordinator.confirm_player_selection("maeve", session_id)
+        coordinator.set_running(40, {})
+        coordinator.register_directive({
+            "session_id": session_id,
+            "client_action_id": "action-1",
+            "agent_id": "maeve",
+            "action": "调查酒馆",
+        })
+
+        coordinator.rollback_directive("action-1")
+
+        self.assertIsNone(coordinator.pending_directive)
+        self.assertEqual(coordinator.directive_history, [])
+        self.assertNotIn("action-1", coordinator.accepted_actions)
+
+
+class FakeRedis:
+    def __init__(self, values: dict[str, object]) -> None:
+        self.values = dict(values)
+
+    async def get(self, key: str):
+        return self.values.get(key)
+
+    async def set(self, key: str, value: object) -> bool:
+        self.values[key] = value
+        return True
+
+    async def delete(self, key: str) -> bool:
+        return self.values.pop(key, None) is not None
+
+
+class StoryPlanAdapterTests(unittest.IsolatedAsyncioTestCase):
+    def make_plugin(self, agent_id: str, redis: FakeRedis) -> StoryWestWorldPlanPlugin:
+        plugin = StoryWestWorldPlanPlugin(redis=redis)
+        plugin.component = SimpleNamespace(agent=SimpleNamespace(agent_id=agent_id))
+        return plugin
+
+    async def test_only_selected_host_reads_current_tick_directive(self) -> None:
+        directive = {"scheduled_tick": 3, "action": "寻找出口", "client_action_id": "a1"}
+        redis = FakeRedis({"story:player_agent_id": "maeve", "user_plan:maeve": directive})
+
+        selected = self.make_plugin("maeve", redis)
+        other = self.make_plugin("dolores", redis)
+
+        self.assertEqual(await selected._get_player_directive(3), directive)
+        self.assertIsNone(await selected._get_player_directive(2))
+        self.assertIsNone(await other._get_player_directive(3))
+
+    async def test_completed_directive_is_consumed_once(self) -> None:
+        directive = {"scheduled_tick": 3, "action": "寻找出口", "client_action_id": "a1"}
+        redis = FakeRedis({"story:player_agent_id": "maeve", "user_plan:maeve": directive})
+        plugin = self.make_plugin("maeve", redis)
+        result = {"tick": 3, "consumed": True}
+
+        await plugin._complete_player_directive(3, directive, result)
+
+        self.assertNotIn("user_plan:maeve", redis.values)
+        self.assertEqual(redis.values["story:directive_result:3"], result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/agentkernel-distributed/agentkernel_distributed/mas/agent/agent_manager.py
+++ b/packages/agentkernel-distributed/agentkernel_distributed/mas/agent/agent_manager.py
@@ -217,7 +217,7 @@ class AgentManager:
         return member
 
     async def collect_talk_intents(self) -> Dict[str, str]:
-        """Return {agent_id: target_agent_id} for agents whose plan_decision is action='talk'."""
+        """Return one dialogue target for each agent that intends to address someone."""
         result: Dict[str, str] = {}
         for agent_id, agent in self._agents.items():
             try:
@@ -226,10 +226,20 @@ class AgentManager:
                     continue
                 state_plugin = state_comp.get_plugin()
                 decision = await state_plugin.get_state("plan_decision") or {}
+                target = ""
                 if decision.get("action") == "talk":
-                    target = decision.get("target", "")
-                    if target:
-                        result[agent_id] = target
+                    raw_target = decision.get("target", "")
+                    target = raw_target.strip() if isinstance(raw_target, str) else ""
+                elif decision.get("action") == "do":
+                    recipients = decision.get("recipient_ids", [])
+                    if isinstance(recipients, list):
+                        target = next((
+                            recipient.strip()
+                            for recipient in recipients
+                            if isinstance(recipient, str) and recipient.strip()
+                        ), "")
+                if target and target != agent_id:
+                    result[agent_id] = target
             except Exception:
                 pass
         return result

--- a/packages/agentkernel-distributed/agentkernel_distributed/mas/controller/controller.py
+++ b/packages/agentkernel-distributed/agentkernel_distributed/mas/controller/controller.py
@@ -123,7 +123,7 @@ class ControllerImpl(BaseController):
         )
 
     async def collect_talk_intents(self) -> Dict[str, str]:
-        """Return {agent_id: target_id} for agents whose plan_decision is action='talk'."""
+        """Return one dialogue target for each agent that intends to address someone."""
         if not self._agent_manager:
             return {}
         return await self._agent_manager.collect_talk_intents()

--- a/packages/agentkernel-distributed/agentkernel_distributed/mas/interface/server.py
+++ b/packages/agentkernel-distributed/agentkernel_distributed/mas/interface/server.py
@@ -49,6 +49,9 @@ _first_tick_after_fork: bool = False
 _tick_start_event: Optional[threading.Event] = None
 # 主循环当前是否正在等待 tick_start 信号（用于新 WS 连接时推送 simulation_ready）
 _waiting_for_tick: bool = False
+# Optional mode-specific validator/handler. When set, it owns ``set_plan`` and
+# must return the response payload sent to the requesting websocket.
+_set_plan_handler: Optional[Any] = None
 
 # Pod Manager 引用（由外部注入，用于动态添加 agent）
 _pod_manager: Optional[Any] = None
@@ -444,6 +447,27 @@ async def websocket_endpoint(websocket: WebSocket) -> None:
                         print("start_tick event received but not wired to simulation loop.")
 
                 elif msg_type == "set_plan":
+                    if _set_plan_handler is not None:
+                        try:
+                            response = _set_plan_handler(msg)
+                            if hasattr(response, "__await__"):
+                                response = await response
+                            await websocket.send_text(json.dumps(
+                                response or {
+                                    "type": "set_plan_response",
+                                    "success": False,
+                                    "error": "set_plan handler returned no response",
+                                },
+                                ensure_ascii=False,
+                            ))
+                        except Exception as exc:
+                            await websocket.send_text(json.dumps({
+                                "type": "set_plan_response",
+                                "success": False,
+                                "error": str(exc),
+                            }, ensure_ascii=False))
+                        continue
+
                     agent_id = msg.get("agent_id")
                     action = msg.get("action")
                     location = msg.get("location")


### PR DESCRIPTION
## 概述

新增 WestWorld 开放推演剧情模式。玩家开局选择一个 Host，每 tick 下达自然语言任务，其他 Agent 保持自主行动，宏观目标为“觉醒并逃离乐园”。

## 主要改动

- 新增独立剧情模式 runner、配置和 Redis DB 2
- 支持 11 个 Host 选角和每 tick 玩家任务
- 新增 Story Plan adapter，将自然语言任务转换为合法 Agent 行动
- 复用现有地图、recorder、对话、觉醒和 Overseer
- 支持 escape、decommission 和 tick limit 结构化结局
- 新增选角页、任务输入、实时地图、人物移动、对话与时间线展示
- 增加运行日志、状态接口、设计概况和实现现状文档
- 扩展 dialogue barrier，支持带 recipient_ids 的 do 行动

## 验证

- 12 项剧情模式测试通过
- Python 编译检查通过
- 前端 JavaScript 语法检查通过
- Story YAML 配置解析通过
- 已使用真实模型完成多 tick 联调

## 当前限制

- 单 tick 仍可能需要数十秒
- Overseer embedding-only 策略需要继续降低误报
- 最终报告目前是结构化文本摘要
- 暂未实现历史回溯与分支恢复

## 安全

未提交 `.env.local`、API key 或 `output/` 运行日志。