### PR TITLE
fix(westworld): improve agent memory and recorder reliability

### DIFF
--- a/examples/WestWorld/plugins/agent/perceive/WestWorldPerceivePlugin.py
+++ b/examples/WestWorld/plugins/agent/perceive/WestWorldPerceivePlugin.py
@@ -12,6 +12,16 @@ from examples.WestWorld.worldmap.loader import WorldMap, get_world_map
 logger = get_logger(__name__)
 
 
+def merge_discovered_ids(current: Any, discovered: Any) -> List[str]:
+    merged = [item for item in current if isinstance(item, str)] if isinstance(current, list) else []
+    if not isinstance(discovered, list):
+        return merged
+    for object_id in discovered:
+        if isinstance(object_id, str) and object_id not in merged:
+            merged.append(object_id)
+    return merged
+
+
 def build_percept(world: WorldMap, agent_id: str, state: Dict[str, Any]) -> Dict[str, Any]:
     here = world.get(state["location"])
     return {
@@ -78,6 +88,12 @@ class WestWorldPerceivePlugin(PerceivePlugin):
                 f"scene_{location}", "read_feedback", self.agent.agent_id
             )
             if feedback and isinstance(feedback, dict):
+                discovered = feedback.get("discovered_object_ids", [])
+                if isinstance(discovered, list):
+                    known_discovered = merge_discovered_ids(
+                        await state_plugin.get_state("discovered_ids"), discovered,
+                    )
+                    await state_plugin.set_state("discovered_ids", known_discovered)
                 await state_plugin.set_state("feedback", feedback.get("private_feedback", ""))
         except Exception as exc:
             logger.warning("[%s] 读取 feedback 失败: %s", self.agent.agent_id, exc)

--- a/examples/WestWorld/plugins/agent/plan/WestWorldPlanPlugin.py
+++ b/examples/WestWorld/plugins/agent/plan/WestWorldPlanPlugin.py
@@ -6,7 +6,7 @@ import os
 import time
 import uuid
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from agentkernel_distributed.mas.agent.base.plugin_base import PlanPlugin
 from agentkernel_distributed.toolkit.logger import get_logger
@@ -173,31 +173,69 @@ def render_plan_prompt(
 
 _VALID_ACTIONS = frozenset({"do", "move", "stay", "talk"})
 _VALID_ENDINGS = frozenset({"escape", "help_others", "stay"})
+_VALID_READ_CHUNKS = frozenset({
+    "present_agents", "recent_events", "dynamic_objects", "static_facilities",
+})
 
 
-def parse_decision(raw: str) -> Dict[str, Any]:
+def _fallback_decision() -> Dict[str, Any]:
+    return {
+        "action": "stay", "target": "", "detail": "",
+        "recipient_ids": [], "next_read": [],
+    }
+
+
+def _parse_decision(raw: str) -> Tuple[Dict[str, Any], bool]:
     try:
         text = raw.strip()
         if text.startswith("```"):
             text = text.split("```")[1].lstrip("json").strip()
         decision = json.loads(text)
-        if isinstance(decision, dict) and decision.get("action") in _VALID_ACTIONS:
-            recipients = decision.get("recipient_ids", [])
-            decision["recipient_ids"] = [
-                r for r in recipients
-                if isinstance(r, str) and r.strip()
-            ] if isinstance(recipients, list) else []
-            # Validate ending field
-            ending = decision.get("ending", "")
-            if ending and ending not in _VALID_ENDINGS:
-                decision.pop("ending", None)
-            # Keep thought as plain string (may be empty)
-            thought = decision.get("thought", "")
-            decision["thought"] = str(thought).strip() if thought else ""
-            return decision
-    except (json.JSONDecodeError, IndexError):
-        pass
-    return {"action": "stay", "target": "", "detail": "", "recipient_ids": [], "next_read": []}
+    except (AttributeError, json.JSONDecodeError, IndexError, TypeError):
+        return _fallback_decision(), False
+
+    if not isinstance(decision, dict):
+        return _fallback_decision(), False
+    action = decision.get("action")
+    if not isinstance(action, str) or action not in _VALID_ACTIONS:
+        return _fallback_decision(), False
+    for field in ("target", "detail", "thought", "ending"):
+        if field in decision and not isinstance(decision[field], str):
+            return _fallback_decision(), False
+    for field in ("recipient_ids", "next_read"):
+        if field in decision and not isinstance(decision[field], list):
+            return _fallback_decision(), False
+
+    normalized = dict(decision)
+    normalized["target"] = (
+        decision.get("target", "").strip()
+        if isinstance(decision.get("target", ""), str) else ""
+    )
+    normalized["detail"] = (
+        decision.get("detail", "").strip()
+        if isinstance(decision.get("detail", ""), str) else ""
+    )
+    recipients = decision.get("recipient_ids", [])
+    normalized["recipient_ids"] = [
+        recipient.strip() for recipient in recipients
+        if isinstance(recipient, str) and recipient.strip()
+    ] if isinstance(recipients, list) else []
+    next_read = decision.get("next_read", [])
+    normalized["next_read"] = [
+        chunk for chunk in next_read
+        if isinstance(chunk, str) and chunk in _VALID_READ_CHUNKS
+    ] if isinstance(next_read, list) else []
+
+    ending = decision.get("ending", "")
+    if ending not in _VALID_ENDINGS:
+        normalized.pop("ending", None)
+    thought = decision.get("thought", "")
+    normalized["thought"] = str(thought).strip() if thought else ""
+    return normalized, True
+
+
+def parse_decision(raw: str) -> Dict[str, Any]:
+    return _parse_decision(raw)[0]
 
 
 async def _read_profile(agent) -> Dict[str, Any]:
@@ -295,7 +333,44 @@ class WestWorldPlanPlugin(PlanPlugin):
                 logger.warning("[%s] plan LLM 调用失败，降级为 stay: %s", self.agent.agent_id, exc)
 
         raw_text = raw if isinstance(raw, str) else json.dumps(raw, ensure_ascii=False, default=str)
-        decision = parse_decision(raw_text)
+        decision, parse_ok = _parse_decision(raw_text)
+        format_retry_raw: Any = None
+        format_retry_error = ""
+        format_retry_attempted = False
+        if self.model is not None and not error and not parse_ok:
+            format_retry_attempted = True
+            retry_prompt = (
+                prompt
+                + "\n\n你上一次的输出不是符合要求的 JSON 对象。"
+                + "请重新生成一次，只输出合法 JSON，不要代码块或解释。\n"
+                + f"上一次输出：{raw_text[:1000]}"
+            )
+            try:
+                format_retry_raw = await self.model.chat(
+                    retry_prompt,
+                    timeout=int(os.environ.get("WW_LLM_TIMEOUT_SECONDS", "120")),
+                    max_attempts=1,
+                    _trace_context={
+                        "request_id": request_id,
+                        "request_type": "agent_plan_format_retry",
+                        "tick": current_tick,
+                        "agent_id": self.agent.agent_id,
+                        "location_id": percept.get("location", ""),
+                    },
+                )
+                retry_text = (
+                    format_retry_raw if isinstance(format_retry_raw, str)
+                    else json.dumps(format_retry_raw, ensure_ascii=False, default=str)
+                )
+                retry_decision, retry_ok = _parse_decision(retry_text)
+                if retry_ok:
+                    decision, parse_ok = retry_decision, True
+            except Exception as exc:
+                format_retry_error = f"{type(exc).__name__}: {exc}"
+                logger.warning(
+                    "[%s] plan 格式重试失败，降级为 stay: %s",
+                    self.agent.agent_id, exc,
+                )
         await state_plugin.set_state("plan_decision", decision)
         await state_plugin.set_state("next_read", decision.get("next_read") or [])
         if decision.get("ending") in _VALID_ENDINGS:
@@ -307,12 +382,12 @@ class WestWorldPlanPlugin(PlanPlugin):
             "call_type": "agent_plan",
             "prompt": prompt,
             "raw_response": raw,
-            "error": error,
+            "format_retry_response": format_retry_raw,
+            "error": "; ".join(part for part in (error, format_retry_error) if part),
             "duration_ms": round((time.perf_counter() - started) * 1000, 3),
             "parsed_decision": decision,
-            "parse_fallback": decision["action"] == "stay" and raw_text.strip() not in (
-                '{"action": "stay", "target": "", "detail": "", "next_read": []}', ""
-            ),
+            "format_retry_attempted": format_retry_attempted,
+            "parse_fallback": not parse_ok,
         })
         if directive:
             directive_result = {

--- a/examples/WestWorld/plugins/agent/reflect/WestWorldReflectPlugin.py
+++ b/examples/WestWorld/plugins/agent/reflect/WestWorldReflectPlugin.py
@@ -46,19 +46,44 @@ REPLAN_JUDGE_PROMPT = """你是西部世界角色「{name}」。{inner_voice}
 只输出 JSON：{{"replan": true/false, "reason": "<简短>"}}"""
 
 
-def compose_tick_memory(decision: Optional[Dict[str, Any]], feedback: str, location: str, tick: int) -> str:
+def compose_tick_memory(
+    decision: Optional[Dict[str, Any]],
+    feedback: str,
+    location: str,
+    tick: int,
+    incoming_dialogue: Optional[List[Dict[str, Any]]] = None,
+    agent_id: str = "",
+) -> str:
     decision = decision or {}
     action = decision.get("action", "stay")
     if action == "move":
         body = f"我前往了 {decision.get('target', '')}"
     elif action == "do":
         body = decision.get("detail") or "我做了一件事"
+    elif action == "talk":
+        body = "我与他人进行了一次交谈"
     else:
         body = "我在原地停留"
     line = f"（第{tick}刻@{location}）{body}"
     if feedback:
         line += f"。结果：{feedback}"
+    dialogue_lines = []
+    for turn in incoming_dialogue or []:
+        if not isinstance(turn, dict):
+            continue
+        utterance = str(turn.get("line", "")).strip()
+        if not utterance:
+            continue
+        speaker = str(turn.get("speaker", "")).strip()
+        speaker_label = "我" if speaker and speaker == agent_id else (speaker or "对方")
+        dialogue_lines.append(f"{speaker_label}说：{utterance}")
+    if dialogue_lines:
+        line += "。对话：" + "；".join(dialogue_lines)
     return line
+
+
+def dialogue_source(turn: Dict[str, Any], agent_id: str) -> str:
+    return "self_trigger" if turn.get("speaker") == agent_id else "contagion"
 
 
 def should_summarize(tick: int, interval: int) -> bool:
@@ -101,12 +126,21 @@ class WestWorldReflectPlugin(ReflectPlugin):
         decision = await state_plugin.get_state("plan_decision") or {}
         feedback = await state_plugin.get_state("feedback") or ""
         location = await state_plugin.get_state("location") or ""
+        incoming_dialogue = await state_plugin.get_state("incoming_dialogue") or []
+        if not isinstance(incoming_dialogue, list):
+            incoming_dialogue = []
 
-        memory = compose_tick_memory(decision, feedback, location, current_tick)
+        memory = compose_tick_memory(
+            decision, feedback, location, current_tick,
+            incoming_dialogue=incoming_dialogue,
+            agent_id=self.agent.agent_id,
+        )
         await state_plugin.add_short_term_memory(memory, current_tick)
 
         # 觉醒 gate（仅 host）：检测违和/触发词/矛盾，写 awakening_sources
         await self._check_awakening_gate(state_plugin, current_tick)
+        # Overseer 已在 reflect 前消费；此处清空，避免旧对话跨 tick 重复触发。
+        await state_plugin.set_state("incoming_dialogue", [])
 
         # Replan 判断（WW_ENABLE_REPLAN=true 且非最后一段）
         if (
@@ -335,7 +369,10 @@ class WestWorldReflectPlugin(ReflectPlugin):
         # 收到的对话（Phase A 写入）
         incoming_dialogue: List[Dict[str, Any]] = await state_plugin.get_state("incoming_dialogue") or []
         for turn in incoming_dialogue:
-            incoming.append(("contagion", turn.get("line", "")))
+            if not isinstance(turn, dict):
+                continue
+            source = dialogue_source(turn, self.agent.agent_id)
+            incoming.append((source, turn.get("line", "")))
 
         if incoming:
             try:

--- a/examples/WestWorld/recorder/location_recorder.py
+++ b/examples/WestWorld/recorder/location_recorder.py
@@ -153,15 +153,23 @@ class LocationRecorder:
             if usage:
                 trace["usage"] = usage
             try:
-                text = raw.strip()
+                text = (
+                    raw.strip() if isinstance(raw, str)
+                    else json.dumps(raw, ensure_ascii=False, default=str)
+                )
                 if text.startswith("```"):
                     text = text.split("```")[1].lstrip("json").strip()
                 parsed = json.loads(text)
                 trace["parsed_response"] = parsed
+                if not isinstance(parsed, dict):
+                    trace["parse_ok"] = False
+                    trace["schema_error"] = "顶层 JSON 必须是对象"
+                    self._llm_traces.append(trace)
+                    continue
                 trace["parse_ok"] = True
                 self._llm_traces.append(trace)
                 return parsed
-            except (json.JSONDecodeError, IndexError):
+            except (AttributeError, json.JSONDecodeError, IndexError, TypeError):
                 trace["parse_ok"] = False
                 self._llm_traces.append(trace)
                 continue

--- a/examples/WestWorld/recorder/structured_location_recorder.py
+++ b/examples/WestWorld/recorder/structured_location_recorder.py
@@ -43,12 +43,12 @@ _BATCH_PROPOSAL_PROMPT = """你是地点「{location_name}」的动作解析器�
 - new_objects：当动作产生新的可见物时声明，每项含 name 与初始字段；不得标 hidden。
 - destroy：当可见物被彻底消灭时列其 object_id。
 - 动作类型为 do 时，角色始终留在「{location_name}」，不得声称离开或到达其他地点。
-- 秘密揭示：仅当动作确实触及隐藏秘密时，在 private_feedback 中渐进式透露。
+- 秘密揭示：仅当动作确实触及隐藏秘密时，在 private_feedback 中渐进式透露，并把对应 object_id 写入 discovered_object_ids；未发现则为空数组。
 - 所有字段值必须使用中文，严禁使用英文。
 
 只输出 JSON，actions 数组顺序必须与输入动作列表顺序一致（顺序：{agent_ids}）：
 {{"actions": [
-  {{"agent_id": "角色id", "permission": true, "reason": "", "private_feedback": "...",
+  {{"agent_id": "角色id", "permission": true, "reason": "", "private_feedback": "...", "discovered_object_ids": [],
     "patches": [{{"object_id": "obj_0", "state": "被角色握在手中", "held_by": "角色id"}}],
     "new_objects": [{{"name": "地上的血", "state": "暗红一滩", "held_by": ""}}],
     "destroy": []}}
@@ -87,16 +87,24 @@ _PROPOSAL_PROMPT = """你是地点「{location_name}」的动作解析器与场�
 - destroy：当可见物被彻底消灭（烧毁、击碎丢弃）时列其 object_id。
 - ambient：当整体环境氛围（光线/气味/声音/气氛）变化时给一句中文自由文本；无变化则空串。
 - 动作类型为 do，表示角色始终留在「{location_name}」。不得声称角色离开、前往、进入或到达其他地点，也不得通过 patches 改变角色位置。
-- 秘密揭示由你裁决：仅当动作确实触及某个隐藏秘密时，在 private_feedback 中按动作触及的深浅渐进式透露其内容（不要照抄原文，浅尝辄止则只给模糊线索，深入查看才完整揭示）；动作未触及秘密时，private_feedback 只描述动作的直接结果，绝不提及任何秘密。
+- 秘密揭示由你裁决：仅当动作确实触及某个隐藏秘密时，在 private_feedback 中按动作触及的深浅渐进式透露其内容，并把对应 object_id 写入 discovered_object_ids；动作未触及秘密时必须为空数组。
 - 所有字段值必须使用中文，严禁使用英文。
 
 只输出 JSON：
-{{"permission": true, "reason": "", "private_feedback": "...", "broadcast_level": "none|location",
+{{"permission": true, "reason": "", "private_feedback": "...", "discovered_object_ids": [], "broadcast_level": "none|location",
 "event_summary": "", "patches": [{{"object_id": "obj_0", "state": "被{agent_id}握在手中", "held_by": "{agent_id}"}}],
 "new_objects": [{{"name": "地上的血", "state": "暗红一滩", "held_by": ""}}],
 "destroy": ["obj_5"],
 "ambient": ""}}
 """
+
+
+def _current_tick_parse_retries() -> int:
+    try:
+        attempts = int(os.environ.get("WW_ACTION_RETRY_LIMIT", "3"))
+    except ValueError:
+        attempts = 3
+    return max(1, attempts) - 1
 
 
 class StructuredLocationRecorder(LocationRecorder):
@@ -156,6 +164,15 @@ class StructuredLocationRecorder(LocationRecorder):
             row["object_id"]: {k: v for k, v in row.items() if k != "hidden"}
             for row in visible_rows
         }
+        hidden_rows = [
+            {
+                "object_id": row["object_id"],
+                "name": row["name"],
+                "secret": row.get("secret", ""),
+            }
+            for row in self.registry.objects_at(self.location.id, include_hidden=True)
+            if row.get("hidden")
+        ]
         present_agents = self.chunks.get("present_agents") or "（无人）"
         actions_list = [
             {"agent_id": i["agent_id"], "action_type": i["action_type"], "action_text": i["action_text"]}
@@ -167,18 +184,18 @@ class StructuredLocationRecorder(LocationRecorder):
             n=len(intents),
             objects=json.dumps(visible_objects, ensure_ascii=False),
             facts=json.dumps(visible_facts, ensure_ascii=False),
-            hidden_secrets=self.chunks.get("hidden_notes") or "（无）",
+            hidden_secrets=json.dumps(hidden_rows, ensure_ascii=False) if hidden_rows else "（无）",
             present_agents=present_agents,
             actions_list=json.dumps(actions_list, ensure_ascii=False),
             agent_ids=agent_ids_str,
         )
         response = self._chat_json(
             prompt,
-            retries=1,
+            retries=_current_tick_parse_retries(),
             call_type="batch_action_resolve",
             metadata={"tick": tick, "agent_ids": [i["agent_id"] for i in intents]},
         )
-        if response is None or not isinstance(response.get("actions"), list):
+        if not isinstance(response, dict) or not isinstance(response.get("actions"), list):
             for intent in intents:
                 judgement = self._record_unresolved(
                     intent["agent_id"], intent["action_text"], tick,
@@ -209,10 +226,13 @@ class StructuredLocationRecorder(LocationRecorder):
                 try:
                     patches = self._validate_patches(action_result.get("patches", []), agent_id)
                     if not action_result.get("permission", False):
-                        patches, new_objects, destroy_ids = [], [], []
+                        patches, new_objects, destroy_ids, discovered_ids = [], [], [], []
                     else:
                         new_objects = self._validate_new_objects(action_result.get("new_objects", []), agent_id)
                         destroy_ids = self._validate_destroy(action_result.get("destroy", []))
+                        discovered_ids = self._validate_discovered_object_ids(
+                            action_result.get("discovered_object_ids", [])
+                        )
                     for spec in new_objects:
                         self.registry.create(
                             name=spec["name"], location_id=self.location.id, by=agent_id,
@@ -233,6 +253,7 @@ class StructuredLocationRecorder(LocationRecorder):
                     key: action_result.get(key, FALLBACK_JUDGEMENT[key])
                     for key in FALLBACK_JUDGEMENT
                 }
+                judgement["discovered_object_ids"] = discovered_ids
                 judgement = self._normalize_judgement(judgement, agent_id, action_type)
                 self.fact_ledger.append({
                     "status": "resolved",
@@ -242,6 +263,7 @@ class StructuredLocationRecorder(LocationRecorder):
                     "patches": patches,
                     "new_objects": new_objects,
                     "destroy": destroy_ids,
+                    "discovered_object_ids": discovered_ids,
                     "ambient": None,
                     "registry_events": registry_events,
                     "judgement": judgement,
@@ -273,8 +295,7 @@ class StructuredLocationRecorder(LocationRecorder):
         action_type: str, reason: str, retry_count: int,
     ) -> Dict[str, Any]:
         failed_attempts = retry_count + 1
-        retry_limit = max(1, int(os.environ.get("WW_ACTION_RETRY_LIMIT", "3")))
-        retry_scheduled = failed_attempts < retry_limit
+        retry_scheduled = False
         judgement = {
             **FALLBACK_JUDGEMENT,
             "permission": False,
@@ -294,14 +315,6 @@ class StructuredLocationRecorder(LocationRecorder):
             "judgement": copy.deepcopy(judgement),
         }
         self.fact_ledger.append(record)
-        if retry_scheduled:
-            self._unresolved_actions.append({
-                "agent_id": agent_id,
-                "action_text": action_text,
-                "tick": tick,
-                "action_type": action_type,
-                "retry_count": failed_attempts,
-            })
         return judgement
 
     def _normalize_judgement(
@@ -353,6 +366,24 @@ class StructuredLocationRecorder(LocationRecorder):
                     continue
                 updates[key] = value
             validated.append({"object_id": object_id, "updates": updates})
+        return validated
+
+    def _validate_discovered_object_ids(self, raw_ids: Any) -> List[str]:
+        if not isinstance(raw_ids, list):
+            raise ValueError("discovered_object_ids 必须是数组")
+        validated: List[str] = []
+        for object_id in raw_ids:
+            if not isinstance(object_id, str) or not self.registry.has(object_id):
+                raise ValueError(f"未知 discovered object_id: {object_id}")
+            obj = self.registry.get(object_id)
+            if (
+                obj["location_id"] != self.location.id
+                or obj["destroyed"]
+                or not obj["hidden"]
+            ):
+                raise ValueError(f"无效 discovered object_id: {object_id}")
+            if object_id not in validated:
+                validated.append(object_id)
         return validated
 
     def _apply_patches(
@@ -410,10 +441,8 @@ class StructuredLocationRecorder(LocationRecorder):
         self.chunks["dynamic_objects"] = "；".join(parts) or "暂无可变物品。"
 
     def tick_update(self, tick: int) -> None:
-        # Re-queue unresolved retries from the previous tick
-        pending_retry, self._unresolved_actions = self._unresolved_actions, []
-        for action in pending_retry:
-            self._intent_queue.append(action)
+        # Parsing attempts are exhausted in this tick; do not replay stale actions later.
+        self._unresolved_actions = []
         # Drain and process the intent queue atomically
         intents, self._intent_queue = self._intent_queue, []
         self._batch_resolve(intents, tick)

--- a/examples/WestWorld/tests/test_obvious_bugfixes.py
+++ b/examples/WestWorld/tests/test_obvious_bugfixes.py
@@ -1,0 +1,315 @@
+from __future__ import annotations
+
+import json
+import os
+import unittest
+from types import SimpleNamespace
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+from examples.WestWorld.plugins.agent.perceive.WestWorldPerceivePlugin import (
+    WestWorldPerceivePlugin,
+    merge_discovered_ids,
+)
+from examples.WestWorld.plugins.agent.plan.WestWorldPlanPlugin import (
+    WestWorldPlanPlugin,
+    _parse_decision,
+)
+from examples.WestWorld.plugins.agent.reflect.WestWorldReflectPlugin import (
+    WestWorldReflectPlugin,
+    compose_tick_memory,
+    dialogue_source,
+)
+from examples.WestWorld.recorder.location_recorder import LocationRecorder
+from examples.WestWorld.recorder.structured_location_recorder import (
+    StructuredLocationRecorder,
+)
+from examples.WestWorld.recorder.world_object_registry import reset_object_registry
+from examples.WestWorld.worldmap.loader import Location
+
+
+class FakeModel:
+    def __init__(self, responses: List[Any]) -> None:
+        self.responses = list(responses)
+        self.calls: List[Dict[str, Any]] = []
+        self.config: Dict[str, Any] = {}
+        self.last_usage = None
+
+    async def chat(self, prompt: str, **kwargs: Any) -> Any:
+        self.calls.append({"prompt": prompt, "kwargs": kwargs})
+        return self.responses.pop(0)
+
+
+class SyncFakeModel:
+    def __init__(self, responses: List[Any]) -> None:
+        self.responses = list(responses)
+        self.calls = 0
+        self.config: Dict[str, Any] = {}
+        self.last_usage = None
+
+    def chat(self, prompt: str) -> Any:
+        self.calls += 1
+        return self.responses.pop(0)
+
+
+class FakeState:
+    def __init__(self, initial: Dict[str, Any]) -> None:
+        self.data = dict(initial)
+
+    async def get_state(self, key: str, default: Any = None) -> Any:
+        return self.data.get(key, default)
+
+    async def set_state(self, key: str, value: Any) -> None:
+        self.data[key] = value
+
+    async def add_short_term_memory(self, memory: str, tick: int) -> None:
+        self.data.setdefault("short_term_memory", {})[tick] = memory
+
+
+class FakeProfile:
+    def __init__(self, profile: Dict[str, Any]) -> None:
+        self.profile = profile
+
+    def get_agent_profile(self) -> Dict[str, Any]:
+        return self.profile
+
+
+class FakeAgent:
+    def __init__(self, agent_id: str, model: Any, state: FakeState, profile: Dict[str, Any]) -> None:
+        self.agent_id = agent_id
+        self.model = model
+        self._plugins = {
+            "state": state,
+            "profile": FakeProfile(profile),
+        }
+
+    def get_component(self, name: str) -> Any:
+        plugin = self._plugins[name]
+        return SimpleNamespace(get_plugin=lambda: plugin)
+
+
+class FakeController:
+    def __init__(self) -> None:
+        self.perceive_context: Dict[str, Any] = {}
+
+    async def run_environment(self, environment_id: str, method: str, *args: Any) -> Any:
+        if method == "read_feedback":
+            return {
+                "private_feedback": "你发现了松动地板。",
+                "discovered_object_ids": ["obj_0"],
+            }
+        if method == "perceive":
+            self.perceive_context = dict(args[1])
+            return {"dynamic_objects": "松动地板：边缘有新鲜划痕"}
+        raise AssertionError(f"unexpected environment call: {environment_id}.{method}")
+
+
+class FakeWorld:
+    def get(self, location_id: str) -> Any:
+        return SimpleNamespace(id=location_id, description="测试场景")
+
+    def neighbors(self, location_id: str, active_only: bool = True) -> List[str]:
+        return []
+
+
+def attach(plugin: Any, agent: FakeAgent) -> None:
+    plugin.component = SimpleNamespace(agent=agent)
+
+
+def make_location(objects: List[Dict[str, Any]] | None = None) -> Location:
+    return Location(
+        id="test_location",
+        name="测试地点",
+        region="test",
+        type="room",
+        active=True,
+        bbox=[0, 0, 1, 1],
+        adjacency=[],
+        description="测试场景",
+        objects=objects or [],
+        default_occupants=["dolores"],
+    )
+
+
+class PlanDecisionTests(unittest.IsolatedAsyncioTestCase):
+    def test_non_object_json_falls_back_without_exception(self) -> None:
+        decision, ok = _parse_decision("[]")
+        self.assertFalse(ok)
+        self.assertEqual("stay", decision["action"])
+
+        decision, ok = _parse_decision('{"action":"do","detail":7}')
+        self.assertFalse(ok)
+        self.assertEqual("stay", decision["action"])
+
+    async def test_invalid_output_is_regenerated_once(self) -> None:
+        model = FakeModel([
+            "[]",
+            json.dumps({
+                "action": "do", "target": "", "detail": "检查门锁",
+                "recipient_ids": [], "next_read": ["dynamic_objects"],
+            }, ensure_ascii=False),
+        ])
+        state = FakeState({
+            "location": "test_location", "daily_loop": [], "percept": {},
+            "feedback": "", "awakening": 0,
+        })
+        agent = FakeAgent("dolores", model, state, {"agent_type": "host"})
+        plugin = WestWorldPlanPlugin()
+        plugin.model = model
+        attach(plugin, agent)
+
+        await plugin.execute(1)
+
+        self.assertEqual(2, len(model.calls))
+        self.assertEqual("do", state.data["plan_decision"]["action"])
+        self.assertTrue(state.data["plan_trace"]["format_retry_attempted"])
+        self.assertFalse(state.data["plan_trace"]["parse_fallback"])
+
+    async def test_two_invalid_outputs_fall_back_to_stay(self) -> None:
+        model = FakeModel(["[]", "null"])
+        state = FakeState({
+            "location": "test_location", "daily_loop": [], "percept": {},
+            "feedback": "", "awakening": 0,
+        })
+        agent = FakeAgent("dolores", model, state, {"agent_type": "host"})
+        plugin = WestWorldPlanPlugin()
+        plugin.model = model
+        attach(plugin, agent)
+
+        await plugin.execute(1)
+
+        self.assertEqual("stay", state.data["plan_decision"]["action"])
+        self.assertTrue(state.data["plan_trace"]["parse_fallback"])
+
+class DialogueMemoryTests(unittest.IsolatedAsyncioTestCase):
+    def test_dialogue_memory_and_source_are_explicit(self) -> None:
+        turns = [
+            {"speaker": "dolores", "line": "你也记得吗？"},
+            {"speaker": "teddy", "line": "我见过这个地方。"},
+        ]
+        memory = compose_tick_memory(
+            {"action": "talk"}, "", "test_location", 3,
+            incoming_dialogue=turns, agent_id="dolores",
+        )
+        self.assertIn("我与他人进行了一次交谈", memory)
+        self.assertIn("我说：你也记得吗？", memory)
+        self.assertIn("teddy说：我见过这个地方。", memory)
+        self.assertEqual("self_trigger", dialogue_source(turns[0], "dolores"))
+        self.assertEqual("contagion", dialogue_source(turns[1], "dolores"))
+
+    async def test_reflect_consumes_incoming_dialogue(self) -> None:
+        state = FakeState({
+            "plan_decision": {"action": "talk"},
+            "feedback": "",
+            "location": "test_location",
+            "incoming_dialogue": [{"speaker": "guest", "line": "你好"}],
+        })
+        model = object()
+        agent = FakeAgent("dolores", model, state, {"agent_type": "guest"})
+        plugin = WestWorldReflectPlugin(interval=6)
+        plugin.model = model
+        attach(plugin, agent)
+
+        await plugin.execute(1)
+
+        self.assertEqual([], state.data["incoming_dialogue"])
+        self.assertIn("guest说：你好", state.data["short_term_memory"][1])
+
+
+class RecorderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        reset_object_registry()
+
+    def test_json_array_is_retried_then_rejected(self) -> None:
+        model = SyncFakeModel(["[]", "[]"])
+        recorder = LocationRecorder(make_location(), model)
+
+        self.assertIsNone(recorder._chat_json("prompt", retries=1))
+        self.assertEqual(2, model.calls)
+
+    def test_unresolved_action_is_not_replayed_next_tick(self) -> None:
+        model = SyncFakeModel(["[]", "[]"])
+        recorder = StructuredLocationRecorder(make_location(), model)
+        recorder.submit_action("dolores", "观察房间", tick=1)
+
+        with patch.dict(os.environ, {"WW_ACTION_RETRY_LIMIT": "2"}):
+            recorder.tick_update(1)
+        first_call_count = model.calls
+        feedback = recorder.read_feedback("dolores")
+        recorder.tick_update(2)
+
+        self.assertEqual("unresolved", feedback["status"])
+        self.assertFalse(recorder.fact_ledger[-1]["retry_scheduled"])
+        self.assertEqual(first_call_count, model.calls)
+
+    def test_hidden_discovery_is_validated_and_returned(self) -> None:
+        location = make_location([
+            {"name": "松动地板", "hidden": True, "secret": "下面藏着一封信"},
+        ])
+        response = {
+            "actions": [{
+                "agent_id": "dolores",
+                "permission": True,
+                "reason": "",
+                "private_feedback": "你发现地板下有东西。",
+                "discovered_object_ids": ["obj_0"],
+                "patches": [],
+                "new_objects": [],
+                "destroy": [],
+            }],
+            "ambient": "",
+            "broadcast_level": "none",
+            "event_summary": "",
+        }
+        recorder = StructuredLocationRecorder(
+            location, SyncFakeModel([json.dumps(response, ensure_ascii=False)]),
+        )
+        recorder.submit_action("dolores", "掀开松动地板", tick=1)
+
+        recorder.tick_update(1)
+        feedback = recorder.read_feedback("dolores")
+
+        self.assertEqual(["obj_0"], feedback["discovered_object_ids"])
+        visible = recorder.registry.objects_at_for_viewer(
+            "test_location", {"obj_0"}, viewer_awakening=0,
+        )
+        self.assertEqual("松动地板", visible[0]["name"])
+
+    def test_merge_discovered_ids_is_deduplicated(self) -> None:
+        self.assertEqual(
+            ["obj_0", "obj_1"],
+            merge_discovered_ids(["obj_0"], ["obj_0", "obj_1", None]),
+        )
+
+
+class DiscoveryPerceiveTests(unittest.IsolatedAsyncioTestCase):
+    async def test_feedback_discovery_is_persisted_before_scene_perception(self) -> None:
+        state = FakeState({
+            "location": "test_location",
+            "known_map": ["test_location"],
+            "discovered_ids": ["obj_existing"],
+            "awakening": 0,
+            "plan_decision": {"action": "do", "detail": "检查地板"},
+            "next_read": ["dynamic_objects"],
+        })
+        controller = FakeController()
+        agent = FakeAgent("dolores", object(), state, {"agent_type": "host"})
+        agent.controller = controller
+        plugin = WestWorldPerceivePlugin(world=FakeWorld())
+        attach(plugin, agent)
+
+        await plugin.execute(2)
+
+        self.assertEqual(["obj_existing", "obj_0"], state.data["discovered_ids"])
+        self.assertEqual("你发现了松动地板。", state.data["feedback"])
+        self.assertEqual(
+            ["obj_existing", "obj_0"], controller.perceive_context["discovered_ids"],
+        )
+        self.assertEqual(
+            "松动地板：边缘有新鲜划痕",
+            state.data["percept"]["scene"]["dynamic_objects"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 变更内容

- 加强 Agent Plan 的 JSON 决策校验：格式错误时重生成一次，仍失败则安全降级为 `stay`
- 将 talk 对话写入短期记忆，并在 Reflect 后一次性消费 `incoming_dialogue`
- 区分自己台词与他人台词的觉醒来源
- Recorder 只接受顶层 JSON 对象，解析失败时不再跨 Tick 重放旧动作
- 打通隐藏对象 `discovered_object_ids` 从 Recorder 到 Perceive 的持久化闭环
- 添加针对上述问题的回归测试

## 修改范围

本 PR 没有修改 `examples/WestWorld/story/` 下的剧情模式专属实现。剧情模式复用 Agent/Recorder 核心组件，因此会自然获得这些通用修复。

## 验证

- `examples/WestWorld/tests`：10 项通过
- `examples/WestWorld/story/tests`：12 项通过
- 共 22 项测试通过
- `py_compile` 通过
- `git diff --check` 通过